### PR TITLE
Migrate Blob service properties related cmdlets and storage account related fixes

### DIFF
--- a/src/Storage/Storage.Management/Blob/DisableAzureStorageBlobDeleteRetentionPolicy.cs
+++ b/src/Storage/Storage.Management/Blob/DisableAzureStorageBlobDeleteRetentionPolicy.cs
@@ -12,11 +12,12 @@
 // limitations under the License.
 // ----------------------------------------------------------------------------------
 
+using Track2 = Azure.ResourceManager.Storage;
+using Track2Models = Azure.ResourceManager.Storage.Models;
+
 namespace Microsoft.Azure.Commands.Management.Storage
 {
     using Microsoft.Azure.Commands.Management.Storage.Models;
-    using Microsoft.Azure.Management.Storage;
-    using Microsoft.Azure.Management.Storage.Models;
     using System;
     using System.Collections.Generic;
     using System.Management.Automation;
@@ -103,17 +104,20 @@ namespace Microsoft.Azure.Commands.Management.Storage
                         // For AccountNameParameterSet, the ResourceGroupName and StorageAccountName can get from input directly
                         break;
                 }
-                BlobServiceProperties serviceProperties = new BlobServiceProperties();
 
-                serviceProperties.DeleteRetentionPolicy = new DeleteRetentionPolicy();
-                serviceProperties.DeleteRetentionPolicy.Enabled = false;
-                serviceProperties.DeleteRetentionPolicy.Days = null;
+                Track2.BlobServiceData data = new Track2.BlobServiceData();
+                data.DeleteRetentionPolicy = new Track2Models.DeleteRetentionPolicy
+                {
+                    Enabled = false,
+                    Days = null,
+                };
 
-                serviceProperties = this.StorageClient.BlobServices.SetServiceProperties(this.ResourceGroupName, this.StorageAccountName, serviceProperties);
-
+                Track2.BlobServiceResource properties = this.StorageClientTrack2.GetBlobServiceResource(this.ResourceGroupName, this.StorageAccountName)
+                    .CreateOrUpdate(global::Azure.WaitUntil.Completed, data).Value;
+                    
                 if (PassThru)
                 {
-                    WriteObject(new PSDeleteRetentionPolicy(serviceProperties.DeleteRetentionPolicy));
+                    WriteObject(new PSDeleteRetentionPolicy(properties.Data.DeleteRetentionPolicy));
                 }
 
             }

--- a/src/Storage/Storage.Management/Blob/DisableAzureStorageBlobLastAccessTimeTracking.cs
+++ b/src/Storage/Storage.Management/Blob/DisableAzureStorageBlobLastAccessTimeTracking.cs
@@ -12,12 +12,13 @@
 // limitations under the License.
 // ----------------------------------------------------------------------------------
 
+using Track2 = Azure.ResourceManager.Storage;
+using Track2Models = Azure.ResourceManager.Storage.Models;
+
 namespace Microsoft.Azure.Commands.Management.Storage
 {
     using Microsoft.Azure.Commands.Management.Storage.Models;
     using Microsoft.Azure.Commands.ResourceManager.Common.ArgumentCompleters;
-    using Microsoft.Azure.Management.Storage;
-    using Microsoft.Azure.Management.Storage.Models;
     using System.Management.Automation;
 
     /// <summary>
@@ -81,12 +82,12 @@ namespace Microsoft.Azure.Commands.Management.Storage
                         // For AccountNameParameterSet, the ResourceGroupName and StorageAccountName can get from input directly
                         break;
                 }
-                BlobServiceProperties serviceProperties = new BlobServiceProperties();
+                Track2.BlobServiceData data = new Track2.BlobServiceData();
 
-                serviceProperties.LastAccessTimeTrackingPolicy = new LastAccessTimeTrackingPolicy();
-                serviceProperties.LastAccessTimeTrackingPolicy.Enable = false;
+                data.LastAccessTimeTrackingPolicy = new Track2Models.LastAccessTimeTrackingPolicy(false);
 
-                serviceProperties = this.StorageClient.BlobServices.SetServiceProperties(this.ResourceGroupName, this.StorageAccountName, serviceProperties);
+                Track2.BlobServiceResource properties = this.StorageClientTrack2.GetBlobServiceResource(this.ResourceGroupName, this.StorageAccountName)
+                    .CreateOrUpdate(global::Azure.WaitUntil.Completed, data).Value;
 
                 if (PassThru)
                 {

--- a/src/Storage/Storage.Management/Blob/DisableAzureStorageBlobRestorePolicy.cs
+++ b/src/Storage/Storage.Management/Blob/DisableAzureStorageBlobRestorePolicy.cs
@@ -12,11 +12,12 @@
 // limitations under the License.
 // ----------------------------------------------------------------------------------
 
+using Track2 = Azure.ResourceManager.Storage;
+using Track2Models = Azure.ResourceManager.Storage.Models;
+
 namespace Microsoft.Azure.Commands.Management.Storage
 {
     using Microsoft.Azure.Commands.Management.Storage.Models;
-    using Microsoft.Azure.Management.Storage;
-    using Microsoft.Azure.Management.Storage.Models;
     using System;
     using System.Collections.Generic;
     using System.Management.Automation;
@@ -104,17 +105,19 @@ namespace Microsoft.Azure.Commands.Management.Storage
                         // For AccountNameParameterSet, the ResourceGroupName and StorageAccountName can get from input directly
                         break;
                 }
-                BlobServiceProperties serviceProperties = new BlobServiceProperties();
+                Track2.BlobServiceData data = new Track2.BlobServiceData();
 
-                serviceProperties.RestorePolicy = new RestorePolicyProperties();
-                serviceProperties.RestorePolicy.Enabled = false;
-                serviceProperties.RestorePolicy.Days = null;
+                data.RestorePolicy = new Track2Models.RestorePolicyProperties(false)
+                {
+                    Days = null,
+                };
 
-                serviceProperties = this.StorageClient.BlobServices.SetServiceProperties(this.ResourceGroupName, this.StorageAccountName, serviceProperties);
+                Track2.BlobServiceResource properties = this.StorageClientTrack2.GetBlobServiceResource(this.ResourceGroupName, this.StorageAccountName)
+                    .CreateOrUpdate(global::Azure.WaitUntil.Completed, data).Value;
 
                 if (PassThru)
                 {
-                    WriteObject(new PSRestorePolicy(serviceProperties.RestorePolicy));
+                    WriteObject(new PSRestorePolicy(properties.Data.RestorePolicy));
                 }
 
             }

--- a/src/Storage/Storage.Management/Blob/DisableAzureStorageContainerDeleteRetentionPolicy.cs
+++ b/src/Storage/Storage.Management/Blob/DisableAzureStorageContainerDeleteRetentionPolicy.cs
@@ -12,13 +12,14 @@
 // limitations under the License.
 // ----------------------------------------------------------------------------------
 
+using Track2 = Azure.ResourceManager.Storage;
+using Track2Models = Azure.ResourceManager.Storage.Models;
+
 namespace Microsoft.Azure.Commands.Management.Storage
 {
     using Microsoft.Azure.Commands.Management.Storage.Models;
     using Microsoft.Azure.Commands.ResourceManager.Common.ArgumentCompleters;
     using Microsoft.Azure.Management.Internal.Resources.Utilities.Models;
-    using Microsoft.Azure.Management.Storage;
-    using Microsoft.Azure.Management.Storage.Models;
     using System.Management.Automation;
 
     /// <summary>
@@ -101,17 +102,20 @@ namespace Microsoft.Azure.Commands.Management.Storage
                         // For AccountNameParameterSet, the ResourceGroupName and StorageAccountName can get from input directly
                         break;
                 }
-                BlobServiceProperties serviceProperties = new BlobServiceProperties();
+                Track2.BlobServiceData data = new Track2.BlobServiceData();
 
-                serviceProperties.ContainerDeleteRetentionPolicy = new DeleteRetentionPolicy();
-                serviceProperties.ContainerDeleteRetentionPolicy.Enabled = false;
-                serviceProperties.ContainerDeleteRetentionPolicy.Days = null;
+                data.ContainerDeleteRetentionPolicy = new Track2Models.DeleteRetentionPolicy
+                {
+                    Enabled = false,
+                    Days = null,
+                };
 
-                serviceProperties = this.StorageClient.BlobServices.SetServiceProperties(this.ResourceGroupName, this.StorageAccountName, serviceProperties);
+                Track2.BlobServiceResource properties = this.StorageClientTrack2.GetBlobServiceResource(this.ResourceGroupName, this.StorageAccountName)
+                    .CreateOrUpdate(global::Azure.WaitUntil.Completed, data).Value;
 
                 if (PassThru)
                 {
-                    WriteObject(new PSDeleteRetentionPolicy(serviceProperties.ContainerDeleteRetentionPolicy));
+                    WriteObject(new PSDeleteRetentionPolicy(properties.Data.ContainerDeleteRetentionPolicy));
                 }
 
             }

--- a/src/Storage/Storage.Management/Blob/EnableAzureStorageBlobDeleteRetentionPolicy.cs
+++ b/src/Storage/Storage.Management/Blob/EnableAzureStorageBlobDeleteRetentionPolicy.cs
@@ -12,11 +12,12 @@
 // limitations under the License.
 // ----------------------------------------------------------------------------------
 
+using Track2 = Azure.ResourceManager.Storage;
+using Track2Models = Azure.ResourceManager.Storage.Models;
+
 namespace Microsoft.Azure.Commands.Management.Storage
 {
     using Microsoft.Azure.Commands.Management.Storage.Models;
-    using Microsoft.Azure.Management.Storage;
-    using Microsoft.Azure.Management.Storage.Models;
     using System;
     using System.Collections.Generic;
     using System.Management.Automation;
@@ -110,18 +111,20 @@ namespace Microsoft.Azure.Commands.Management.Storage
                         // For AccountNameParameterSet, the ResourceGroupName and StorageAccountName can get from input directly
                         break;
                 }
-                BlobServiceProperties serviceProperties = new BlobServiceProperties();
+                Track2.BlobServiceData data = new Track2.BlobServiceData();
 
-                serviceProperties.DeleteRetentionPolicy = new DeleteRetentionPolicy();
-                serviceProperties.DeleteRetentionPolicy.Enabled = true;
-                serviceProperties.DeleteRetentionPolicy.Days = RetentionDays;
-                serviceProperties.DeleteRetentionPolicy.AllowPermanentDelete = this.AllowPermanentDelete.IsPresent ? true : false;
+                data.DeleteRetentionPolicy = new Track2Models.DeleteRetentionPolicy
+                {
+                    Enabled = true,
+                    Days = RetentionDays,
+                };
 
-                serviceProperties = this.StorageClient.BlobServices.SetServiceProperties(this.ResourceGroupName, this.StorageAccountName, serviceProperties);
+                Track2.BlobServiceResource properties = this.StorageClientTrack2.GetBlobServiceResource(this.ResourceGroupName, this.StorageAccountName)
+                    .CreateOrUpdate(global::Azure.WaitUntil.Completed, data).Value;
 
                 if (PassThru)
                 {
-                    WriteObject(new PSDeleteRetentionPolicy(serviceProperties.DeleteRetentionPolicy));
+                    WriteObject(new PSDeleteRetentionPolicy(properties.Data.DeleteRetentionPolicy));
                 }
 
             }

--- a/src/Storage/Storage.Management/Blob/EnableAzureStorageBlobLastAccessTimeTracking.cs
+++ b/src/Storage/Storage.Management/Blob/EnableAzureStorageBlobLastAccessTimeTracking.cs
@@ -12,12 +12,13 @@
 // limitations under the License.
 // ----------------------------------------------------------------------------------
 
+using Track2 = Azure.ResourceManager.Storage;
+using Track2Models = Azure.ResourceManager.Storage.Models;
+
 namespace Microsoft.Azure.Commands.Management.Storage
 {
     using Microsoft.Azure.Commands.Management.Storage.Models;
     using Microsoft.Azure.Commands.ResourceManager.Common.ArgumentCompleters;
-    using Microsoft.Azure.Management.Storage;
-    using Microsoft.Azure.Management.Storage.Models;
     using System.Management.Automation;
 
     /// <summary>
@@ -86,20 +87,18 @@ namespace Microsoft.Azure.Commands.Management.Storage
                         // For AccountNameParameterSet, the ResourceGroupName and StorageAccountName can get from input directly
                         break;
                 }
-                BlobServiceProperties serviceProperties = new BlobServiceProperties();
+                Track2.BlobServiceData data = new Track2.BlobServiceData();
 
-                serviceProperties.LastAccessTimeTrackingPolicy = new LastAccessTimeTrackingPolicy();
-                serviceProperties.LastAccessTimeTrackingPolicy.Enable = true;
+                data.LastAccessTimeTrackingPolicy = new Track2Models.LastAccessTimeTrackingPolicy(true);
 
-                serviceProperties = this.StorageClient.BlobServices.SetServiceProperties(this.ResourceGroupName, this.StorageAccountName, serviceProperties);
-
+                Track2.BlobServiceResource properties = this.StorageClientTrack2.GetBlobServiceResource(this.ResourceGroupName, this.StorageAccountName)
+                    .CreateOrUpdate(global::Azure.WaitUntil.Completed, data).Value;
 
                 if (PassThru)
                 {
                     //Get the full service properties from server for output
-                    serviceProperties = this.StorageClient.BlobServices.GetServiceProperties(this.ResourceGroupName, this.StorageAccountName);
-
-                    WriteObject(new PSLastAccessTimeTrackingPolicy(serviceProperties.LastAccessTimeTrackingPolicy));
+                    properties = this.StorageClientTrack2.GetBlobServiceResource(this.ResourceGroupName, this.StorageAccountName).Get().Value;
+                    WriteObject(new PSLastAccessTimeTrackingPolicy(properties.Data.LastAccessTimeTrackingPolicy));
                 }
 
             }

--- a/src/Storage/Storage.Management/Blob/EnableAzureStorageBlobRestorePolicy.cs
+++ b/src/Storage/Storage.Management/Blob/EnableAzureStorageBlobRestorePolicy.cs
@@ -12,11 +12,12 @@
 // limitations under the License.
 // ----------------------------------------------------------------------------------
 
+using Track2 = Azure.ResourceManager.Storage;
+using Track2Models = Azure.ResourceManager.Storage.Models;
+
 namespace Microsoft.Azure.Commands.Management.Storage
 {
     using Microsoft.Azure.Commands.Management.Storage.Models;
-    using Microsoft.Azure.Management.Storage;
-    using Microsoft.Azure.Management.Storage.Models;
     using System;
     using System.Collections.Generic;
     using System.Management.Automation;
@@ -108,17 +109,20 @@ namespace Microsoft.Azure.Commands.Management.Storage
                         // For AccountNameParameterSet, the ResourceGroupName and StorageAccountName can get from input directly
                         break;
                 }
-                BlobServiceProperties serviceProperties = new BlobServiceProperties();
 
-                serviceProperties.RestorePolicy = new RestorePolicyProperties();
-                serviceProperties.RestorePolicy.Enabled = true;
-                serviceProperties.RestorePolicy.Days = RestoreDays;
+                Track2.BlobServiceData data = new Track2.BlobServiceData();
 
-                serviceProperties = this.StorageClient.BlobServices.SetServiceProperties(this.ResourceGroupName, this.StorageAccountName, serviceProperties);
+                data.RestorePolicy = new Track2Models.RestorePolicyProperties(true)
+                {
+                    Days = this.RestoreDays,
+                };
+
+                Track2.BlobServiceResource properties = this.StorageClientTrack2.GetBlobServiceResource(this.ResourceGroupName, this.StorageAccountName)
+                    .CreateOrUpdate(global::Azure.WaitUntil.Completed, data).Value;
 
                 if (PassThru)
                 {
-                    WriteObject(new PSRestorePolicy(serviceProperties.RestorePolicy));
+                    WriteObject(new PSRestorePolicy(properties.Data.RestorePolicy));
                 }
 
             }

--- a/src/Storage/Storage.Management/Blob/EnableAzureStorageContainerDeleteRetentionPolicy.cs
+++ b/src/Storage/Storage.Management/Blob/EnableAzureStorageContainerDeleteRetentionPolicy.cs
@@ -12,13 +12,14 @@
 // limitations under the License.
 // ----------------------------------------------------------------------------------
 
+using Track2 = Azure.ResourceManager.Storage;
+using Track2Models = Azure.ResourceManager.Storage.Models;
+
 namespace Microsoft.Azure.Commands.Management.Storage
 {
     using Microsoft.Azure.Commands.Management.Storage.Models;
     using Microsoft.Azure.Commands.ResourceManager.Common.ArgumentCompleters;
     using Microsoft.Azure.Management.Internal.Resources.Utilities.Models;
-    using Microsoft.Azure.Management.Storage;
-    using Microsoft.Azure.Management.Storage.Models;
     using System.Management.Automation;
 
     /// <summary>
@@ -105,17 +106,19 @@ namespace Microsoft.Azure.Commands.Management.Storage
                         // For AccountNameParameterSet, the ResourceGroupName and StorageAccountName can get from input directly
                         break;
                 }
-                BlobServiceProperties serviceProperties = new BlobServiceProperties();
+                Track2.BlobServiceData data = new Track2.BlobServiceData();
+                data.ContainerDeleteRetentionPolicy = new Track2Models.DeleteRetentionPolicy
+                {
+                    Enabled = true,
+                    Days = this.RetentionDays,
+                };
 
-                serviceProperties.ContainerDeleteRetentionPolicy = new DeleteRetentionPolicy();
-                serviceProperties.ContainerDeleteRetentionPolicy.Enabled = true;
-                serviceProperties.ContainerDeleteRetentionPolicy.Days = RetentionDays;
-
-                serviceProperties = this.StorageClient.BlobServices.SetServiceProperties(this.ResourceGroupName, this.StorageAccountName, serviceProperties);
+                Track2.BlobServiceResource properties = this.StorageClientTrack2.GetBlobServiceResource(this.ResourceGroupName, this.StorageAccountName)
+                    .CreateOrUpdate(global::Azure.WaitUntil.Completed, data).Value;
 
                 if (PassThru)
                 {
-                    WriteObject(new PSDeleteRetentionPolicy(serviceProperties.ContainerDeleteRetentionPolicy));
+                    WriteObject(new PSDeleteRetentionPolicy(properties.Data.ContainerDeleteRetentionPolicy));
                 }
 
             }

--- a/src/Storage/Storage.Management/Blob/GetAzureStorageBlobServiceProperties.cs
+++ b/src/Storage/Storage.Management/Blob/GetAzureStorageBlobServiceProperties.cs
@@ -12,18 +12,18 @@
 // limitations under the License.
 // ----------------------------------------------------------------------------------
 
+using Track2 = Azure.ResourceManager.Storage;
+
 namespace Microsoft.Azure.Commands.Management.Storage
 {
     using Microsoft.Azure.Commands.Management.Storage.Models;
-    using Microsoft.Azure.Management.Storage;
-    using Microsoft.Azure.Management.Storage.Models;
     using System;
     using System.Collections.Generic;
     using System.Management.Automation;
     using Microsoft.Azure.Commands.ResourceManager.Common.ArgumentCompleters;
     using Microsoft.Azure.Management.Internal.Resources.Utilities.Models;
     using Microsoft.WindowsAzure.Commands.Common.CustomAttributes;
-
+    
     /// <summary>
     /// Modify Azure Storage service properties
     /// </summary>
@@ -99,7 +99,10 @@ namespace Microsoft.Azure.Commands.Management.Storage
                     // For AccountNameParameterSet, the ResourceGroupName and StorageAccountName can get from input directly
                     break;
             }
-            BlobServiceProperties serviceProperties = this.StorageClient.BlobServices.GetServiceProperties(this.ResourceGroupName, this.StorageAccountName);
+
+            Track2.BlobServiceResource serviceProperties = this.StorageClientTrack2
+                .GetBlobServiceResource(this.ResourceGroupName, this.StorageAccountName)
+                .Get();
 
             WriteObject(new PSBlobServiceProperties(serviceProperties));
         }

--- a/src/Storage/Storage.Management/Blob/StorageBlobBaseCmdlet.cs
+++ b/src/Storage/Storage.Management/Blob/StorageBlobBaseCmdlet.cs
@@ -43,6 +43,13 @@ namespace Microsoft.Azure.Commands.Management.Storage
 
         public const string StorageAccountResourceType = "Microsoft.Storage/storageAccounts";
 
+        protected struct RootSquashType
+        {
+            internal const string NoRootSquash = "NoRootSquash";
+            internal const string RootSquash = "RootSquash";
+            internal const string AllSquash = "AllSquash";
+        }
+
         public IStorageManagementClient StorageClient
         {
             get
@@ -62,26 +69,24 @@ namespace Microsoft.Azure.Commands.Management.Storage
             set { storageClientWrapper = new StorageManagementClientWrapper(value); }
         }
 
+        private Track2StorageManagementClient _track2StorageManagementClient;
+        public Track2StorageManagementClient StorageClientTrack2
+        {
+            get
+            {
+                return _track2StorageManagementClient ?? (_track2StorageManagementClient = new Track2StorageManagementClient(
+                    Microsoft.Azure.Commands.Common.Authentication.AzureSession.Instance.ClientFactory,
+                    DefaultContext));
+            }
+
+            set { _track2StorageManagementClient = value; }
+        }
+
         public string SubscriptionId
         {
             get
             {
                 return DefaultProfile.DefaultContext.Subscription.Id.ToString();
-            }
-        }
-
-        protected void WriteContainer(ListContainerItem container)
-        {
-            WriteObject(new PSContainer(container));
-        }
-
-        protected void WriteContainerList(IEnumerable<ListContainerItem> containers)
-        {
-            if (containers != null)
-            {
-                List<PSContainer> output = new List<PSContainer>();
-                containers.ForEach(container => output.Add(new PSContainer(container)));
-                WriteObject(output, true);
             }
         }
 

--- a/src/Storage/Storage.Management/Models/PSStorageAccount.cs
+++ b/src/Storage/Storage.Management/Models/PSStorageAccount.cs
@@ -288,7 +288,10 @@ namespace Microsoft.Azure.Commands.Management.Storage.Models
             {
                 this.TenantId = identity.TenantId.Value.ToString();
             }
-            if (identity != null)
+            if (identity.ManagedServiceIdentityType == ManagedServiceIdentityType.SystemAssignedUserAssigned)
+            {
+                this.Type = "SystemAssigned,UserAssigned";
+            } else
             {
                 this.Type = identity.ManagedServiceIdentityType.ToString();
             }

--- a/src/Storage/Storage.Management/Models/PSStorageAccount.cs
+++ b/src/Storage/Storage.Management/Models/PSStorageAccount.cs
@@ -166,6 +166,8 @@ namespace Microsoft.Azure.Commands.Management.Storage.Models
 
         public PSImmutableStorageAccount ImmutableStorageWithVersioning { get; set; }
 
+        // TODO: StorageAccountSkuConversionStatus is not supported yet. Will add later.
+
         public static PSStorageAccount Create(Track2.StorageAccountResource storageAccountResource, Track2StorageManagementClient client)
         {
             var result = new PSStorageAccount(storageAccountResource);

--- a/src/Storage/Storage.Management/Models/PSStorageAccount.cs
+++ b/src/Storage/Storage.Management/Models/PSStorageAccount.cs
@@ -32,7 +32,6 @@ namespace Microsoft.Azure.Commands.Management.Storage.Models
 {
     public class PSStorageAccount : IStorageContextProvider
     {
-
         public PSStorageAccount(Track2.StorageAccountResource storageAccountResource)
         {
             this.ResourceGroupName = new ResourceIdentifier(storageAccountResource.Id).ResourceGroupName;
@@ -270,6 +269,7 @@ namespace Microsoft.Azure.Commands.Management.Storage.Models
 
     public class PSIdentity
     {
+        private const string SystemAssignedUserAssigned = "SystemAssigned,UserAssigned";
         public string PrincipalId { get; set; }
         public string TenantId { get; set; }
 
@@ -290,7 +290,7 @@ namespace Microsoft.Azure.Commands.Management.Storage.Models
             }
             if (identity.ManagedServiceIdentityType == ManagedServiceIdentityType.SystemAssignedUserAssigned)
             {
-                this.Type = "SystemAssigned,UserAssigned";
+                this.Type = SystemAssignedUserAssigned;
             } else
             {
                 this.Type = identity.ManagedServiceIdentityType.ToString();

--- a/src/Storage/Storage.Management/Storage.Management.csproj
+++ b/src/Storage/Storage.Management/Storage.Management.csproj
@@ -14,6 +14,17 @@
     <RootNamespace>$(LegacyAssemblyPrefix)$(PsModuleName)</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Remove="Blob\DisableAzureStorageBlobDeleteRetentionPolicy.cs" />
+    <Compile Remove="Blob\DisableAzureStorageBlobRestorePolicy.cs" />
+    <Compile Remove="Blob\DisableAzureStorageContainerDeleteRetentionPolicy.cs" />
+    <Compile Remove="Blob\EnableAzureStorageBlobDeleteRetentionPolicy.cs" />
+    <Compile Remove="Blob\EnableAzureStorageBlobLastAccessTimeTracking.cs" />
+    <Compile Remove="Blob\EnableAzureStorageBlobRestorePolicy.cs" />
+    <Compile Remove="Blob\EnableAzureStorageContainerDeleteRetentionPolicy.cs" />
+    <Compile Remove="Blob\GetAzureStorageContainer.cs" />
+    <Compile Remove="File\GetAzStorageFileServiceProperty.cs" />
+    <Compile Remove="File\UpdateAzAzStorageFileServiceProperty.cs" />
+    <Compile Remove="Models\PSFileServiceProperties.cs" />
     <Compile Remove="StorageAccount\AddAzureStorageAccountNetworkRule.cs" />
     <Compile Remove="StorageAccount\GetAzureStorageAccountNetworkRuleSet.cs" />
     <Compile Remove="StorageAccount\InvokeAzureStorageAccountHierarchicalNamespaceUpgrade.cs" />

--- a/src/Storage/Storage.Management/Storage.Management.csproj
+++ b/src/Storage/Storage.Management/Storage.Management.csproj
@@ -14,13 +14,6 @@
     <RootNamespace>$(LegacyAssemblyPrefix)$(PsModuleName)</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Remove="Blob\DisableAzureStorageBlobDeleteRetentionPolicy.cs" />
-    <Compile Remove="Blob\DisableAzureStorageBlobRestorePolicy.cs" />
-    <Compile Remove="Blob\DisableAzureStorageContainerDeleteRetentionPolicy.cs" />
-    <Compile Remove="Blob\EnableAzureStorageBlobDeleteRetentionPolicy.cs" />
-    <Compile Remove="Blob\EnableAzureStorageBlobLastAccessTimeTracking.cs" />
-    <Compile Remove="Blob\EnableAzureStorageBlobRestorePolicy.cs" />
-    <Compile Remove="Blob\EnableAzureStorageContainerDeleteRetentionPolicy.cs" />
     <Compile Remove="Blob\GetAzureStorageContainer.cs" />
     <Compile Remove="File\GetAzStorageFileServiceProperty.cs" />
     <Compile Remove="File\UpdateAzAzStorageFileServiceProperty.cs" />

--- a/src/Storage/Storage.Management/StorageAccount/NewAzureStorageAccount.cs
+++ b/src/Storage/Storage.Management/StorageAccount/NewAzureStorageAccount.cs
@@ -644,8 +644,10 @@ namespace Microsoft.Azure.Commands.Management.Storage
                         new Track2Models.ActiveDirectoryProperties(this.ActiveDirectoryDomainName, this.ActiveDirectoryNetBiosDomainName,
                         this.ActiveDirectoryForestName, this.ActiveDirectoryDomainGuid, this.ActiveDirectoryDomainSid, this.ActiveDirectoryAzureStorageSid);
                     createContent.AzureFilesIdentityBasedAuthentication.ActiveDirectoryProperties.SamAccountName = this.ActiveDirectorySamAccountName;
-                    createContent.AzureFilesIdentityBasedAuthentication.ActiveDirectoryProperties.AccountType = this.ActiveDirectoryAccountType;
-
+                    if (this.ActiveDirectoryAccountType != null)
+                    {
+                        createContent.AzureFilesIdentityBasedAuthentication.ActiveDirectoryProperties.AccountType = this.ActiveDirectoryAccountType;
+                    }
                 }
                 else
                 {

--- a/src/Storage/Storage.Management/StorageAccount/SetAzureStorageAccount.cs
+++ b/src/Storage/Storage.Management/StorageAccount/SetAzureStorageAccount.cs
@@ -683,8 +683,10 @@ namespace Microsoft.Azure.Commands.Management.Storage
                                 new Track2Models.ActiveDirectoryProperties(this.ActiveDirectoryDomainName, this.ActiveDirectoryNetBiosDomainName,
                                 this.ActiveDirectoryForestName, this.ActiveDirectoryDomainGuid, this.ActiveDirectoryDomainSid, this.ActiveDirectoryAzureStorageSid);
                             storageAccountPatch.AzureFilesIdentityBasedAuthentication.ActiveDirectoryProperties.SamAccountName = this.ActiveDirectorySamAccountName;
-                            storageAccountPatch.AzureFilesIdentityBasedAuthentication.ActiveDirectoryProperties.AccountType = this.ActiveDirectoryAccountType;
-
+                            if (this.ActiveDirectoryAccountType != null)
+                            {
+                                storageAccountPatch.AzureFilesIdentityBasedAuthentication.ActiveDirectoryProperties.AccountType = this.ActiveDirectoryAccountType;
+                            }
                         }
                         else // Disable AD
                         {
@@ -708,7 +710,7 @@ namespace Microsoft.Azure.Commands.Management.Storage
                                 || originStorageAccount.Data.AzureFilesIdentityBasedAuthentication.DirectoryServiceOptions == Track2Models.DirectoryServiceOptions.AD)
                             {
                                 storageAccountPatch.AzureFilesIdentityBasedAuthentication =
-                                    new Track2Models.AzureFilesIdentityBasedAuthentication(Track2Models.DirectoryServiceOptions.AD);
+                                    new Track2Models.AzureFilesIdentityBasedAuthentication(Track2Models.DirectoryServiceOptions.None);
 
                             }
                             else
@@ -745,11 +747,14 @@ namespace Microsoft.Azure.Commands.Management.Storage
                     {
                         storageAccountPatch.RoutingPreference = new Track2Models.RoutingPreference
                         {
-                            RoutingChoice = this.RoutingChoice,
                             PublishInternetEndpoints = this.publishInternetEndpoint,
                             PublishMicrosoftEndpoints = this.publishMicrosoftEndpoint,
 
                         };
+                        if (this.RoutingChoice != null)
+                        {
+                            storageAccountPatch.RoutingPreference.RoutingChoice = new Track2Models.RoutingChoice(this.RoutingChoice);
+                        }
                     }
                     if (allowSharedKeyAccess != null)
                     {

--- a/src/Storage/Storage.Management/StorageAccount/StorageAccountBaseCmdlet.cs
+++ b/src/Storage/Storage.Management/StorageAccount/StorageAccountBaseCmdlet.cs
@@ -226,7 +226,8 @@ namespace Microsoft.Azure.Commands.Management.Storage
             if (storageAccountResource.GetKeys()?.Value?.Keys != null && storageAccountResource.GetKeys().Value.Keys.Count > 0)
             {
                 key = storageAccountResource.GetKeys().Value.Keys[0].Value;
-            } else
+            } 
+            else
             {
                 throw new InvalidJobStateException("Could not fetch storage account keys to build storage account context.");
             }


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
This PR includes migration of Get-AzStorageBlobServiceProperty and Update-AzStorageBlobServiceProperty to Track2 SDK, and fixes of Set/New-AzStorageAccount. 

<!-- Please add a brief description of the changes made in this PR -->

## Checklist

- [x] I have read the [_Submitting Changes_](../blob/master/CONTRIBUTING.md#submitting-changes) section of [`CONTRIBUTING.md`](../blob/master/CONTRIBUTING.md)
- [x] The title of the PR is clear and informative
- [x] The appropriate `ChangeLog.md` file(s) has been updated:
    - For any service, the `ChangeLog.md` file can be found at `src/{{SERVICE}}/{{SERVICE}}/ChangeLog.md`
    - A snippet outlining the change(s) made in the PR should be written under the `## Upcoming Release` header -- no new version header should be added
- [x] The PR does not introduce [breaking changes](../blob/master/documentation/breaking-changes/breaking-changes-definition.md)
- [x] If applicable, the changes made in the PR have proper test coverage
- [x] For public API changes to cmdlets:
    - [ ] a cmdlet design review was approved for the changes in [this repository](https://github.com/Azure/azure-powershell-cmdlet-review-pr) (_Microsoft internal only_)
    - [ ] the markdown help files have been regenerated using the commands listed [here](../blob/master/documentation/development-docs/help-generation.md#updating-all-markdown-files-in-a-module)
