### PR TITLE
Migrate BlobInventoryPolicy related cmdelts and Invoke-AzStorageAccountFailover to Track2 SDK 

### DIFF
--- a/src/Storage/Storage.Management/Models/PSBlobInventoryPolicy.cs
+++ b/src/Storage/Storage.Management/Models/PSBlobInventoryPolicy.cs
@@ -39,6 +39,7 @@ namespace Microsoft.Azure.Commands.Management.Storage.Models
             this.LastModifiedTime = policy.Data.LastModifiedOn;
             this.SystemData = policy.Data.SystemData is null ? null : new PSSystemData(policy.Data.SystemData);
             this.Enabled = policy.Data.Policy.Enabled;
+            // TODO: Destination is currently not supported yet. Will add later. 
 
             if (policy.Data.Policy.Rules != null)
             {

--- a/src/Storage/Storage.Management/Models/PSBlobInventoryPolicy.cs
+++ b/src/Storage/Storage.Management/Models/PSBlobInventoryPolicy.cs
@@ -12,6 +12,8 @@
 // limitations under the License.
 // ----------------------------------------------------------------------------------
 
+using Track2 = Azure.ResourceManager.Storage;
+using Track2Models = Azure.ResourceManager.Storage.Models;
 using Microsoft.Azure.Management.Storage.Models;
 using Microsoft.WindowsAzure.Commands.Common.Attributes;
 using System;
@@ -27,23 +29,21 @@ namespace Microsoft.Azure.Commands.Management.Storage.Models
         public PSBlobInventoryPolicy()
         { }
 
-        public PSBlobInventoryPolicy(BlobInventoryPolicy policy, string ResourceGroupName, string StorageAccountName)
+        public PSBlobInventoryPolicy(Track2.BlobInventoryPolicyResource policy, string resourceGroupName, string storageAccountName)
         {
-            this.ResourceGroupName = ResourceGroupName;
-            this.StorageAccountName = StorageAccountName;
+            this.ResourceGroupName = resourceGroupName;
+            this.StorageAccountName = storageAccountName;
             this.Id = policy.Id;
-            this.Name = policy.Name;
-            this.Type = policy.Type;
-            this.LastModifiedTime = policy.LastModifiedTime;
-            this.SystemData = policy.SystemData is null ? null : new PSSystemData(policy.SystemData);
+            this.Name = policy.Data.Name;
+            this.Type = policy.Data.ResourceType;
+            this.LastModifiedTime = policy.Data.LastModifiedOn;
+            this.SystemData = policy.Data.SystemData is null ? null : new PSSystemData(policy.Data.SystemData);
+            this.Enabled = policy.Data.Policy.Enabled;
 
-            this.Enabled = policy.Policy.Enabled;
-            this.Destination = policy.Policy.Destination;
-
-            if (policy.Policy.Rules != null)
+            if (policy.Data.Policy.Rules != null)
             {
                 List<PSBlobInventoryPolicyRule> psRules = new List<PSBlobInventoryPolicyRule>();
-                foreach (BlobInventoryPolicyRule rule in policy.Policy.Rules)
+                foreach (Track2Models.BlobInventoryPolicyRule rule in policy.Data.Policy.Rules)
                 {
                     psRules.Add(new PSBlobInventoryPolicyRule(rule));
                 }
@@ -55,32 +55,29 @@ namespace Microsoft.Azure.Commands.Management.Storage.Models
             }
         }
 
-        public BlobInventoryPolicy ParseBlobInventoryPolicy()
-        {
-            List<BlobInventoryPolicyRule> invRules = ParseBlobInventoryPolicyRules(this.Rules);
 
-            BlobInventoryPolicySchema policySchema = new BlobInventoryPolicySchema()
+        public Track2.BlobInventoryPolicyData ParseBlobInventoryPolicy()
+        {
+            List<Track2Models.BlobInventoryPolicyRule> invRules = ParseBlobInventoryPolicyRules(this.Rules);
+
+            Track2Models.BlobInventoryPolicySchema policySchema = new Track2Models.BlobInventoryPolicySchema(
+                this.Enabled,
+                Track2Models.InventoryRuleType.Inventory,
+                invRules);
+
+            Track2.BlobInventoryPolicyData data = new Track2.BlobInventoryPolicyData
             {
-                Enabled = this.Enabled,
-                //Destination = this.Destination,
-                Rules = invRules
+                Policy = policySchema,
             };
-            return new BlobInventoryPolicy(
-                policySchema,
-                this.Id,
-                this.Name,
-                this.Type,
-                this.LastModifiedTime,
-                this.SystemData is null ? null : this.SystemData.ParseSystemData()
-            );
+            return data;
         }
 
-        public static List<BlobInventoryPolicyRule> ParseBlobInventoryPolicyRules(PSBlobInventoryPolicyRule[] rules)
+        public static List<Track2Models.BlobInventoryPolicyRule> ParseBlobInventoryPolicyRules(PSBlobInventoryPolicyRule[] rules)
         {
-            List<BlobInventoryPolicyRule> invRules = null;
+            List<Track2Models.BlobInventoryPolicyRule> invRules = null;
             if (rules != null)
             {
-                invRules = new List<BlobInventoryPolicyRule>();
+                invRules = new List<Track2Models.BlobInventoryPolicyRule>();
                 foreach (PSBlobInventoryPolicyRule rule in rules)
                 {
                     invRules.Add(rule.ParseBlobInventoryPolicyRule());
@@ -99,7 +96,7 @@ namespace Microsoft.Azure.Commands.Management.Storage.Models
         [Ps1Xml(Label = "Type", Target = ViewControl.List, Position = 2)]
         public string Type { get; set; }
         [Ps1Xml(Label = "LastModifiedTime", Target = ViewControl.List, Position = 4)]
-        public DateTime? LastModifiedTime { get; set; }
+        public DateTimeOffset? LastModifiedTime { get; set; }
 
         //public PSBlobInventoryPolicySchema Policy { get; set; }
 
@@ -108,7 +105,6 @@ namespace Microsoft.Azure.Commands.Management.Storage.Models
         [Ps1Xml(Label = "Rules", Target = ViewControl.List, Position = 7)]
         public PSBlobInventoryPolicyRule[] Rules { get; set; }
         public PSSystemData SystemData { get; set; }
-        public string Destination { get; private set; }
     }
 
     /// <summary>
@@ -117,7 +113,7 @@ namespace Microsoft.Azure.Commands.Management.Storage.Models
     public class PSBlobInventoryPolicyRule
     {
         public PSBlobInventoryPolicyRule() { }
-        public PSBlobInventoryPolicyRule(BlobInventoryPolicyRule rule)
+        public PSBlobInventoryPolicyRule(Track2Models.BlobInventoryPolicyRule rule)
         {
             this.Enabled = rule.Enabled;
             this.Name = rule.Name;
@@ -125,15 +121,17 @@ namespace Microsoft.Azure.Commands.Management.Storage.Models
             this.Definition = rule.Definition is null ? null : new PSBlobInventoryPolicyDefinition(rule.Definition);
         }
 
-        public BlobInventoryPolicyRule ParseBlobInventoryPolicyRule()
+        public Track2Models.BlobInventoryPolicyRule ParseBlobInventoryPolicyRule()
         {
-            return new BlobInventoryPolicyRule()
-            {
-                Enabled = this.Enabled,
-                Name = this.Name,
-                Destination = this.Destination,
-                Definition = this.Definition is null ? null : this.Definition.parseBlobInventoryPolicyDefinition()
-            };
+            Track2Models.BlobInventoryPolicyDefinition policyDefinition = this.Definition?.parseBlobInventoryPolicyDefinition();
+
+            Track2Models.BlobInventoryPolicyRule policyRule = new Track2Models.BlobInventoryPolicyRule(
+                this.Enabled,
+                this.Name,
+                this.Destination,
+                policyDefinition);
+
+            return policyRule;
         }
 
         public bool Enabled { get; set; }
@@ -152,20 +150,29 @@ namespace Microsoft.Azure.Commands.Management.Storage.Models
     {
         public PSBlobInventoryPolicyDefinition() { }
 
-        public PSBlobInventoryPolicyDefinition(BlobInventoryPolicyDefinition Definition)
+        public PSBlobInventoryPolicyDefinition(Track2Models.BlobInventoryPolicyDefinition Definition)
         {
             this.Filters = Definition.Filters is null ? null : new PSBlobInventoryPolicyFilter(Definition.Filters);
-            this.Format = Definition.Format;
-            this.Schedule = Definition.Schedule;
-            this.ObjectType = Definition.ObjectType;
+            this.Format = Definition.Format.ToString();
+            this.Schedule = Definition.Schedule.ToString();
+            this.ObjectType = Definition.ObjectType.ToString();
             this.SchemaFields = Definition.SchemaFields is null ? null : ((List<string>)Definition.SchemaFields).ToArray();
         }
 
-        public BlobInventoryPolicyDefinition parseBlobInventoryPolicyDefinition()
+        public Track2Models.BlobInventoryPolicyDefinition parseBlobInventoryPolicyDefinition()
         {
-            return new BlobInventoryPolicyDefinition(this.Format, this.Schedule, this.ObjectType, 
-                this.SchemaFields is null? null: new List<string>(this.SchemaFields),
-                this.Filters is null? null : this.Filters.ParseBlobInventoryPolicyFilter());
+            Track2Models.BlobInventoryPolicyDefinition policyDefinition = new Track2Models.BlobInventoryPolicyDefinition(
+                new Track2Models.Format(this.Format),
+                new Track2Models.Schedule(this.Schedule),
+                new Track2Models.ObjectType(this.ObjectType),
+                this.SchemaFields is null ? null : new List<string>(this.SchemaFields)
+                );
+
+            if (this.Filters != null)
+            {
+                policyDefinition.Filters = this.Filters.ParseBlobInventoryPolicyFilter();
+            }
+            return policyDefinition;
         }
 
         public PSBlobInventoryPolicyFilter Filters { get; set; }
@@ -213,7 +220,7 @@ namespace Microsoft.Azure.Commands.Management.Storage.Models
     {
         public PSBlobInventoryPolicyFilter() { }
 
-        public PSBlobInventoryPolicyFilter(BlobInventoryPolicyFilter filters)
+        public PSBlobInventoryPolicyFilter(Track2Models.BlobInventoryPolicyFilter filters)
         {
             this.PrefixMatch = PSManagementPolicyRuleFilter.StringListToArray(filters.PrefixMatch);
             this.BlobTypes = PSManagementPolicyRuleFilter.StringListToArray(filters.BlobTypes);
@@ -221,15 +228,29 @@ namespace Microsoft.Azure.Commands.Management.Storage.Models
             this.IncludeSnapshots = filters.IncludeSnapshots;
         }
 
-        public BlobInventoryPolicyFilter ParseBlobInventoryPolicyFilter()
+        public Track2Models.BlobInventoryPolicyFilter ParseBlobInventoryPolicyFilter()
         {
-            return new BlobInventoryPolicyFilter()
+            Track2Models.BlobInventoryPolicyFilter policyFilter = new Track2Models.BlobInventoryPolicyFilter()
             {
-                PrefixMatch = PSManagementPolicyRuleFilter.StringArrayToList(this.PrefixMatch),
-                BlobTypes = PSManagementPolicyRuleFilter.StringArrayToList(this.BlobTypes),
                 IncludeSnapshots = this.IncludeSnapshots,
                 IncludeBlobVersions = this.IncludeBlobVersions
             };
+
+            if (this.PrefixMatch != null)
+            {
+                foreach (string prefixMatch in this.PrefixMatch)
+                {
+                    policyFilter.PrefixMatch.Add(prefixMatch);
+                }
+            }
+            if (this.BlobTypes != null)
+            {
+                foreach (string blobType in this.BlobTypes)
+                {
+                    policyFilter.BlobTypes.Add(blobType);
+                }
+            }
+            return policyFilter;
         }
 
         public string[] PrefixMatch { get; set; }
@@ -245,26 +266,21 @@ namespace Microsoft.Azure.Commands.Management.Storage.Models
     {
         public PSSystemData() { }
 
-        public PSSystemData(SystemData SystemData)
+        public PSSystemData(global::Azure.ResourceManager.Models.SystemData SystemData)
         {
             this.CreatedBy = SystemData.CreatedBy;
-            this.CreatedByType = SystemData.CreatedByType;
-            this.CreatedAt = SystemData.CreatedAt;
+            this.CreatedByType = SystemData.CreatedByType.ToString();
+            this.CreatedAt = SystemData.CreatedOn;
             this.LastModifiedBy = SystemData.LastModifiedBy;
-            this.LastModifiedByType = SystemData.LastModifiedByType;
-            this.LastModifiedAt = SystemData.LastModifiedAt;
-        }
-
-        public SystemData ParseSystemData()
-        {
-            return new SystemData(this.CreatedBy, this.CreatedByType, this.CreatedAt, this.LastModifiedBy, this.LastModifiedByType, this.LastModifiedAt);
+            this.LastModifiedByType = SystemData.LastModifiedByType.ToString();
+            this.LastModifiedAt = SystemData.LastModifiedOn;
         }
 
         public string CreatedBy { get; set; }
         public string CreatedByType { get; set; }
-        public DateTime? CreatedAt { get; set; }
+        public DateTimeOffset? CreatedAt { get; set; }
         public string LastModifiedBy { get; set; }
         public string LastModifiedByType { get; set; }
-        public DateTime? LastModifiedAt { get; set; }
+        public DateTimeOffset? LastModifiedAt { get; set; }
     }
 }

--- a/src/Storage/Storage.Management/Storage.Management.csproj
+++ b/src/Storage/Storage.Management/Storage.Management.csproj
@@ -19,7 +19,6 @@
     <Compile Remove="File\UpdateAzAzStorageFileServiceProperty.cs" />
     <Compile Remove="Models\PSFileServiceProperties.cs" />
     <Compile Remove="StorageAccount\InvokeAzureStorageAccountHierarchicalNamespaceUpgrade.cs" />
-    <Compile Remove="StorageAccount\InvokeAzureStorageAccountFailover.cs" />
   </ItemGroup>
   <ItemGroup>
     <!-- <PackageReference Include="Azure.Core" Version="1.24.0" /> -->

--- a/src/Storage/Storage.Management/StorageAccount/GetAzureStorageBlobInventoryPolicy.cs
+++ b/src/Storage/Storage.Management/StorageAccount/GetAzureStorageBlobInventoryPolicy.cs
@@ -39,6 +39,11 @@ namespace Microsoft.Azure.Commands.Management.Storage
         /// </summary>
         private const string AccountResourceIdParameterSet = "AccountResourceId";
 
+        /// <summary>
+        /// Default policy name 
+        /// </summary>
+        private const string DefaultPolicyName = "default";
+
         [Parameter(
          Position = 0,
          Mandatory = true,
@@ -95,7 +100,7 @@ namespace Microsoft.Azure.Commands.Management.Storage
             }
 
             Track2.BlobInventoryPolicyResource policy =
-                this.StorageClientTrack2.GetBlobInventoryPolicyResource(this.ResourceGroupName, this.StorageAccountName, "default").Get();
+                this.StorageClientTrack2.GetBlobInventoryPolicyResource(this.ResourceGroupName, this.StorageAccountName, DefaultPolicyName).Get();
 
             WriteObject(new PSBlobInventoryPolicy(policy, this.ResourceGroupName, this.StorageAccountName), true);
         }

--- a/src/Storage/Storage.Management/StorageAccount/GetAzureStorageBlobInventoryPolicy.cs
+++ b/src/Storage/Storage.Management/StorageAccount/GetAzureStorageBlobInventoryPolicy.cs
@@ -15,10 +15,9 @@
 using Microsoft.Azure.Commands.Management.Storage.Models;
 using Microsoft.Azure.Commands.ResourceManager.Common.ArgumentCompleters;
 using Microsoft.Azure.Management.Internal.Resources.Utilities.Models;
-using Microsoft.Azure.Management.Storage;
-using Microsoft.Azure.Management.Storage.Models;
 using Microsoft.WindowsAzure.Commands.Common.CustomAttributes;
 using System.Management.Automation;
+using Track2 = Azure.ResourceManager.Storage;
 
 namespace Microsoft.Azure.Commands.Management.Storage
 {
@@ -95,9 +94,8 @@ namespace Microsoft.Azure.Commands.Management.Storage
                     break;
             }
 
-            BlobInventoryPolicy policy = this.StorageClient.BlobInventoryPolicies.Get(
-                 this.ResourceGroupName,
-                 this.StorageAccountName);
+            Track2.BlobInventoryPolicyResource policy =
+                this.StorageClientTrack2.GetBlobInventoryPolicyResource(this.ResourceGroupName, this.StorageAccountName, "default").Get();
 
             WriteObject(new PSBlobInventoryPolicy(policy, this.ResourceGroupName, this.StorageAccountName), true);
         }

--- a/src/Storage/Storage.Management/StorageAccount/InvokeAzureStorageAccountFailover.cs
+++ b/src/Storage/Storage.Management/StorageAccount/InvokeAzureStorageAccountFailover.cs
@@ -12,16 +12,13 @@
 // limitations under the License.
 // ----------------------------------------------------------------------------------
 
+using Microsoft.Azure.Commands.Management.Storage.Models;
+using Microsoft.Azure.Commands.ResourceManager.Common.ArgumentCompleters;
+using Microsoft.Azure.Commands.ResourceManager.Common.Tags;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Management.Automation;
-using Microsoft.Azure.Commands.ResourceManager.Common.Tags;
-using Microsoft.Azure.Management.Storage;
-using Microsoft.Azure.Management.Storage.Models;
-using StorageModels = Microsoft.Azure.Management.Storage.Models;
-using Microsoft.Azure.Commands.Management.Storage.Models;
-using Microsoft.Azure.Commands.ResourceManager.Common.ArgumentCompleters;
-using System;
 using System.Text;
 
 namespace Microsoft.Azure.Commands.Management.Storage
@@ -89,7 +86,6 @@ namespace Microsoft.Azure.Commands.Management.Storage
                 shouldContinuePrompt.AppendLine("  2. After the failover, your storage account type will be converted to locally redundant storage (LRS). You can convert your account to use geo-redundant storage (GRS).");
                 shouldContinuePrompt.AppendLine("  3. Once you re-enable GRS for your storage account, Microsoft will replicate data to your new secondary region. Replication time is dependent on the amount of data to replicate. Please note that there are bandwidth charges for the bootstrap. Please refer to doc: https://azure.microsoft.com/en-us/pricing/details/bandwidth/");
 
-
                 if (this.force || ShouldContinue(shouldContinuePrompt.ToString(), ""))
                 {
                     if (ParameterSetName == AccountObjectParameterSet)
@@ -98,11 +94,8 @@ namespace Microsoft.Azure.Commands.Management.Storage
                         this.Name = InputObject.StorageAccountName;
                     }
 
-                    this.StorageClient.StorageAccounts.Failover(
-                        this.ResourceGroupName,
-                        this.Name);
-
-                    var storageAccount = this.StorageClient.StorageAccounts.GetProperties(this.ResourceGroupName, this.Name);
+                    this.StorageClientTrack2.GetStorageAccount(this.ResourceGroupName, this.Name).Failover(global::Azure.WaitUntil.Completed);
+                    var storageAccount = this.StorageClientTrack2.GetStorageAccount(this.ResourceGroupName, this.Name).Get();
 
                     WriteStorageAccount(storageAccount);
                 }

--- a/src/Storage/Storage.Management/StorageAccount/NewAzureStorageBlobInventoryPolicyRule.cs
+++ b/src/Storage/Storage.Management/StorageAccount/NewAzureStorageBlobInventoryPolicyRule.cs
@@ -14,13 +14,11 @@
 
 using Microsoft.Azure.Commands.Management.Storage.Models;
 using Microsoft.Azure.Commands.ResourceManager.Common.ArgumentCompleters;
-using Microsoft.Azure.Management.Storage;
-using Microsoft.Azure.Management.Storage.Models;
 using Microsoft.WindowsAzure.Commands.Common.CustomAttributes;
 using System.Collections.Generic;
 using System.Management.Automation;
 using System.Reflection;
-using StorageModels = Microsoft.Azure.Management.Storage.Models;
+
 
 namespace Microsoft.Azure.Commands.Management.Storage
 {

--- a/src/Storage/Storage.Management/StorageAccount/NewAzureStorageBlobInventoryPolicyRule.cs
+++ b/src/Storage/Storage.Management/StorageAccount/NewAzureStorageBlobInventoryPolicyRule.cs
@@ -19,7 +19,6 @@ using System.Collections.Generic;
 using System.Management.Automation;
 using System.Reflection;
 
-
 namespace Microsoft.Azure.Commands.Management.Storage
 {
     [Cmdlet("New", ResourceManager.Common.AzureRMConstants.AzureRMPrefix + "StorageBlobInventoryPolicyRule", DefaultParameterSetName = BlobRuleParameterSet), OutputType(typeof(PSBlobInventoryPolicyRule))]

--- a/src/Storage/Storage.Management/StorageAccount/RemoveAzureStorageBlobInventoryPolicy.cs
+++ b/src/Storage/Storage.Management/StorageAccount/RemoveAzureStorageBlobInventoryPolicy.cs
@@ -15,9 +15,8 @@
 using Microsoft.Azure.Commands.Management.Storage.Models;
 using Microsoft.Azure.Commands.ResourceManager.Common.ArgumentCompleters;
 using Microsoft.Azure.Management.Internal.Resources.Utilities.Models;
-using Microsoft.Azure.Management.Storage;
-using Microsoft.Azure.Management.Storage.Models;
 using System.Management.Automation;
+using Azure;
 
 namespace Microsoft.Azure.Commands.Management.Storage
 {
@@ -115,10 +114,7 @@ namespace Microsoft.Azure.Commands.Management.Storage
                         // For AccountNameParameterSet, the ResourceGroupName and StorageAccountName can get from input directly
                         break;
                 }
-
-                this.StorageClient.BlobInventoryPolicies.Delete(
-                    this.ResourceGroupName,
-                    this.StorageAccountName);
+                this.StorageClientTrack2.GetBlobInventoryPolicyResource(this.ResourceGroupName, this.StorageAccountName, "default").Delete(WaitUntil.Completed);
 
                 if (PassThru.IsPresent)
                 {


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
This PR includes migration of BlobInventoryPolicy related cmdlets and Invoke-AzStorageAccountFailover to Track2 SDK.
BlobInventoryPolicy related cmdlets include Get-AzStorageBlobInventoryPolicy, New-AzStorageBlobInventoryPolicyRule, Remove-AzStorageBlobInventoryPolicy, Set-AzStorageBlobInventoryPolicy

<!-- Please add a brief description of the changes made in this PR -->

## Checklist

- [x] I have read the [_Submitting Changes_](../blob/master/CONTRIBUTING.md#submitting-changes) section of [`CONTRIBUTING.md`](../blob/master/CONTRIBUTING.md)
- [x] The title of the PR is clear and informative
- [x] The appropriate `ChangeLog.md` file(s) has been updated:
    - For any service, the `ChangeLog.md` file can be found at `src/{{SERVICE}}/{{SERVICE}}/ChangeLog.md`
    - A snippet outlining the change(s) made in the PR should be written under the `## Upcoming Release` header -- no new version header should be added
- [x] The PR does not introduce [breaking changes](../blob/master/documentation/breaking-changes/breaking-changes-definition.md)
- [x] If applicable, the changes made in the PR have proper test coverage
- [x] For public API changes to cmdlets:
    - [ ] a cmdlet design review was approved for the changes in [this repository](https://github.com/Azure/azure-powershell-cmdlet-review-pr) (_Microsoft internal only_)
    - [ ] the markdown help files have been regenerated using the commands listed [here](../blob/master/documentation/development-docs/help-generation.md#updating-all-markdown-files-in-a-module)
