### PR TITLE
Upgrade SDK version to 1.0.0-beta.10 

### DIFF
--- a/src/Storage/Storage.Management/Models/PSDataPolicy.cs
+++ b/src/Storage/Storage.Management/Models/PSDataPolicy.cs
@@ -1,4 +1,5 @@
 ﻿// ----------------------------------------------------------------------------------
+// ----------------------------------------------------------------------------------
 //
 // Copyright Microsoft Corporation
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +13,8 @@
 // limitations under the License.
 // ----------------------------------------------------------------------------------
 
-using Track2 = global::Azure.ResourceManager.Storage;
+using Track2 = Azure.ResourceManager.Storage;
+using Track2Models = Azure.ResourceManager.Storage.Models;
 using Azure.ResourceManager.Storage.Models;
 using Microsoft.WindowsAzure.Commands.Common.Attributes;
 using System;
@@ -67,16 +69,16 @@ namespace Microsoft.Azure.Commands.Management.Storage.Models
         {
         }
 
-        public PSManagementPolicyRule(global::Azure.ResourceManager.Storage.Models.ManagementPolicyRule rule)
+        public PSManagementPolicyRule(Track2Models.ManagementPolicyRule rule)
         {
             this.Enabled = rule.Enabled;
             this.Name = rule.Name;
             this.Definition = rule.Definition is null ? null : new PSManagementPolicyDefinition(rule.Definition);
         }
 
-        public Track2.Models.ManagementPolicyRule ParseManagementPolicyRule()
+        public Track2Models.ManagementPolicyRule ParseManagementPolicyRule()
         {
-            Track2.Models.ManagementPolicyRule rule = new Track2.Models.ManagementPolicyRule(
+            Track2Models.ManagementPolicyRule rule = new Track2Models.ManagementPolicyRule(
                 this.Name,
                 RuleType.Lifecycle,
                 this.Definition?.ParseManagementPolicyDefination()
@@ -85,7 +87,7 @@ namespace Microsoft.Azure.Commands.Management.Storage.Models
             return rule;
         }
 
-        public static PSManagementPolicyRule[] GetPSManagementPolicyRules(IList<Track2.Models.ManagementPolicyRule> rules)
+        public static PSManagementPolicyRule[] GetPSManagementPolicyRules(IList<Track2Models.ManagementPolicyRule> rules)
         {
             if (rules == null)
             {
@@ -273,9 +275,9 @@ namespace Microsoft.Azure.Commands.Management.Storage.Models
         public PSManagementPolicySnapShot(Track2.Models.ManagementPolicySnapShot blobAction)
         {
 
-            this.Delete = blobAction.DeleteDaysAfterCreationGreaterThan is null ? null : new PSDateAfterCreation((int)blobAction.DeleteDaysAfterCreationGreaterThan);
-            this.TierToCool = blobAction.TierToCoolDaysAfterCreationGreaterThan is null ? null : new PSDateAfterCreation((int)blobAction.TierToCoolDaysAfterCreationGreaterThan);
-            TierToArchive = blobAction.TierToArchiveDaysAfterCreationGreaterThan is null ? null : new PSDateAfterCreation((int)blobAction.TierToArchiveDaysAfterCreationGreaterThan);
+            this.Delete = blobAction.Delete is null ? null : new PSDateAfterCreation((int)blobAction.Delete.DaysAfterCreationGreaterThan);
+            this.TierToCool = blobAction.TierToCool is null ? null : new PSDateAfterCreation((int)blobAction.TierToCool.DaysAfterCreationGreaterThan);
+            TierToArchive = blobAction.TierToArchive is null ? null : new PSDateAfterCreation((int)blobAction.TierToArchive.DaysAfterCreationGreaterThan);
         }
         public Track2.Models.ManagementPolicySnapShot ParseManagementPolicySnapShot()
         {
@@ -284,15 +286,17 @@ namespace Microsoft.Azure.Commands.Management.Storage.Models
 
             if (this.Delete != null)
             {
-                snapShot.DeleteDaysAfterCreationGreaterThan = this.Delete.DaysAfterCreationGreaterThan;
+                snapShot.Delete = new Track2.Models.DateAfterCreation(this.Delete.DaysAfterCreationGreaterThan);
             }
             if (this.TierToCool != null)
             {
-                snapShot.TierToCoolDaysAfterCreationGreaterThan = this.TierToCool.DaysAfterCreationGreaterThan;
+                snapShot.TierToCool = new Track2.Models.DateAfterCreation(this.TierToCool.DaysAfterCreationGreaterThan);
+                //snapShot.TierToCoolDaysAfterCreationGreaterThan = this.TierToCool.DaysAfterCreationGreaterThan;
             }
             if (this.TierToArchive != null)
             {
-                snapShot.TierToArchiveDaysAfterCreationGreaterThan = this.TierToArchive.DaysAfterCreationGreaterThan;
+                snapShot.TierToArchive = new Track2.Models.DateAfterCreation(this.TierToArchive.DaysAfterCreationGreaterThan);
+                //snapShot.TierToArchiveDaysAfterCreationGreaterThan = this.TierToArchive.DaysAfterCreationGreaterThan;
             }
 
             return snapShot;
@@ -313,24 +317,27 @@ namespace Microsoft.Azure.Commands.Management.Storage.Models
 
         public PSManagementPolicyVersion(Track2.Models.ManagementPolicyVersion blobAction)
         {
-            this.Delete = blobAction.DeleteDaysAfterCreationGreaterThan is null ? null : new PSDateAfterCreation((int)blobAction.DeleteDaysAfterCreationGreaterThan);
-            this.TierToCool = blobAction.TierToCoolDaysAfterCreationGreaterThan is null ? null :new PSDateAfterCreation((int)blobAction.TierToCoolDaysAfterCreationGreaterThan);
-            this.TierToArchive = blobAction.TierToArchiveDaysAfterCreationGreaterThan is null ? null : new PSDateAfterCreation((int)blobAction.TierToArchiveDaysAfterCreationGreaterThan);
+            this.Delete = blobAction.Delete is null ? null : new PSDateAfterCreation((int)blobAction.Delete.DaysAfterCreationGreaterThan);
+            this.TierToCool = blobAction.TierToCool is null ? null :new PSDateAfterCreation((int)blobAction.TierToCool.DaysAfterCreationGreaterThan);
+            this.TierToArchive = blobAction.TierToArchive is null ? null : new PSDateAfterCreation((int)blobAction.TierToArchive.DaysAfterCreationGreaterThan);
         }
         public Track2.Models.ManagementPolicyVersion ParseManagementPolicyVersion()
         {
             Track2.Models.ManagementPolicyVersion policyVersion = new Track2.Models.ManagementPolicyVersion();
             if (this.Delete != null)
             {
-                policyVersion.DeleteDaysAfterCreationGreaterThan = this.Delete.DaysAfterCreationGreaterThan;
+                policyVersion.Delete = new DateAfterCreation(this.Delete.DaysAfterCreationGreaterThan);
+                //policyVersion.DeleteDaysAfterCreationGreaterThan = this.Delete.DaysAfterCreationGreaterThan;
             }
             if (this.TierToCool != null)
             {
-                policyVersion.TierToCoolDaysAfterCreationGreaterThan = this.TierToCool.DaysAfterCreationGreaterThan;
+                policyVersion.TierToCool = new DateAfterCreation(this.TierToCool.DaysAfterCreationGreaterThan);
+                //policyVersion.TierToCoolDaysAfterCreationGreaterThan = this.TierToCool.DaysAfterCreationGreaterThan;
             }
             if (this.TierToArchive != null)
             {
-                policyVersion.TierToArchiveDaysAfterCreationGreaterThan = this.TierToArchive.DaysAfterCreationGreaterThan;
+                policyVersion.TierToArchive = new DateAfterCreation(this.TierToArchive.DaysAfterCreationGreaterThan);
+                //policyVersion.TierToArchiveDaysAfterCreationGreaterThan = this.TierToArchive.DaysAfterCreationGreaterThan;
             }
 
             return policyVersion;

--- a/src/Storage/Storage.Management/Models/PSDataPolicy.cs
+++ b/src/Storage/Storage.Management/Models/PSDataPolicy.cs
@@ -1,5 +1,4 @@
 ﻿// ----------------------------------------------------------------------------------
-// ----------------------------------------------------------------------------------
 //
 // Copyright Microsoft Corporation
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,12 +12,12 @@
 // limitations under the License.
 // ----------------------------------------------------------------------------------
 
-using Track2 = Azure.ResourceManager.Storage;
-using Track2Models = Azure.ResourceManager.Storage.Models;
 using Azure.ResourceManager.Storage.Models;
 using Microsoft.WindowsAzure.Commands.Common.Attributes;
 using System;
 using System.Collections.Generic;
+using Track2 = Azure.ResourceManager.Storage;
+using Track2Models = Azure.ResourceManager.Storage.Models;
 
 namespace Microsoft.Azure.Commands.Management.Storage.Models
 {
@@ -94,20 +93,20 @@ namespace Microsoft.Azure.Commands.Management.Storage.Models
                 return null;
             }
             List<PSManagementPolicyRule> psrules = new List<PSManagementPolicyRule>();
-            foreach (Track2.Models.ManagementPolicyRule rule in rules)
+            foreach (Track2Models.ManagementPolicyRule rule in rules)
             {
                 psrules.Add(new PSManagementPolicyRule(rule));
             }
             return psrules.ToArray();
         }
 
-        public static List<Track2.Models.ManagementPolicyRule> ParseManagementPolicyRules(PSManagementPolicyRule[] psrules)
+        public static List<Track2Models.ManagementPolicyRule> ParseManagementPolicyRules(PSManagementPolicyRule[] psrules)
         {
             if (psrules == null)
             {
                 return null;
             }
-            List<Track2.Models.ManagementPolicyRule> rules = new List<Track2.Models.ManagementPolicyRule>();
+            List<Track2Models.ManagementPolicyRule> rules = new List<Track2Models.ManagementPolicyRule>();
             foreach (PSManagementPolicyRule psrule in psrules)
             {
                 rules.Add(psrule.ParseManagementPolicyRule());
@@ -128,15 +127,15 @@ namespace Microsoft.Azure.Commands.Management.Storage.Models
         {
         }
 
-        public PSManagementPolicyDefinition(Track2.Models.ManagementPolicyDefinition defination)
+        public PSManagementPolicyDefinition(Track2Models.ManagementPolicyDefinition defination)
         {
             this.Actions = defination.Actions is null ? null : new PSManagementPolicyActionGroup(defination.Actions);
             this.Filters = defination.Filters is null ? null : new PSManagementPolicyRuleFilter(defination.Filters);
         }
-        public Track2.Models.ManagementPolicyDefinition ParseManagementPolicyDefination()
+        public Track2Models.ManagementPolicyDefinition ParseManagementPolicyDefination()
         {
-            Track2.Models.ManagementPolicyAction actions = this.Actions?.ParseManagementPolicyAction();
-            Track2.Models.ManagementPolicyDefinition policyDefinition = new Track2.Models.ManagementPolicyDefinition(actions);
+            Track2Models.ManagementPolicyAction actions = this.Actions?.ParseManagementPolicyAction();
+            Track2Models.ManagementPolicyDefinition policyDefinition = new Track2Models.ManagementPolicyDefinition(actions);
             policyDefinition.Filters = this.Filters?.ParseManagementPolicyFilter();
 
             return policyDefinition;
@@ -159,14 +158,14 @@ namespace Microsoft.Azure.Commands.Management.Storage.Models
         public PSManagementPolicyRuleFilter()
         { }
 
-        public PSManagementPolicyRuleFilter(Track2.Models.ManagementPolicyFilter filter)
+        public PSManagementPolicyRuleFilter(Track2Models.ManagementPolicyFilter filter)
         {
             this.PrefixMatch = StringListToArray(filter.PrefixMatch);
             this.BlobTypes = StringListToArray(filter.BlobTypes);
         }
-        public Track2.Models.ManagementPolicyFilter ParseManagementPolicyFilter()
+        public Track2Models.ManagementPolicyFilter ParseManagementPolicyFilter()
         {
-            Track2.Models.ManagementPolicyFilter policyFilter = new Track2.Models.ManagementPolicyFilter(StringArrayToList(this.BlobTypes));
+            Track2Models.ManagementPolicyFilter policyFilter = new Track2Models.ManagementPolicyFilter(StringArrayToList(this.BlobTypes));
             if (this.PrefixMatch != null)
             {
                 foreach (string prefixMatch in this.PrefixMatch)
@@ -211,15 +210,15 @@ namespace Microsoft.Azure.Commands.Management.Storage.Models
         public PSManagementPolicyActionGroup()
         { }
 
-        public PSManagementPolicyActionGroup(Track2.Models.ManagementPolicyAction action)
+        public PSManagementPolicyActionGroup(Track2Models.ManagementPolicyAction action)
         {
             this.BaseBlob = (action is null || action.BaseBlob is null) ? null : new PSManagementPolicyBaseBlob(action.BaseBlob);
             this.Snapshot = (action is null || action.Snapshot is null) ? null : new PSManagementPolicySnapShot(action.Snapshot);
             this.Version = (action is null || action.Version is null) ? null : new PSManagementPolicyVersion(action.Version);
         }
-        public Track2.Models.ManagementPolicyAction ParseManagementPolicyAction()
+        public Track2Models.ManagementPolicyAction ParseManagementPolicyAction()
         {
-            return new Track2.Models.ManagementPolicyAction()
+            return new Track2Models.ManagementPolicyAction()
             {
                 BaseBlob = this.BaseBlob?.ParseManagementPolicyBaseBlob(),
                 Snapshot = this.Snapshot?.ParseManagementPolicySnapShot(),
@@ -241,16 +240,16 @@ namespace Microsoft.Azure.Commands.Management.Storage.Models
         public PSManagementPolicyBaseBlob()
         { }
 
-        public PSManagementPolicyBaseBlob(Track2.Models.ManagementPolicyBaseBlob blobAction)
+        public PSManagementPolicyBaseBlob(Track2Models.ManagementPolicyBaseBlob blobAction)
         {
             this.TierToCool = blobAction.TierToCool is null ? null : new PSDateAfterModification(blobAction.TierToCool);
             this.TierToArchive = blobAction.TierToArchive is null ? null : new PSDateAfterModification(blobAction.TierToArchive);
             this.Delete = blobAction.Delete is null ? null : new PSDateAfterModification(blobAction.Delete);
             this.EnableAutoTierToHotFromCool = blobAction.EnableAutoTierToHotFromCool;
         }
-        public Track2.Models.ManagementPolicyBaseBlob ParseManagementPolicyBaseBlob()
+        public Track2Models.ManagementPolicyBaseBlob ParseManagementPolicyBaseBlob()
         {
-            return new Track2.Models.ManagementPolicyBaseBlob()
+            return new Track2Models.ManagementPolicyBaseBlob()
             {
                 TierToCool = this.TierToCool?.ParseDateAfterModification(),
                 TierToArchive = this.TierToArchive?.ParseDateAfterModification(),
@@ -272,31 +271,29 @@ namespace Microsoft.Azure.Commands.Management.Storage.Models
         public PSManagementPolicySnapShot()
         { }
 
-        public PSManagementPolicySnapShot(Track2.Models.ManagementPolicySnapShot blobAction)
+        public PSManagementPolicySnapShot(Track2Models.ManagementPolicySnapShot blobAction)
         {
 
             this.Delete = blobAction.Delete is null ? null : new PSDateAfterCreation((int)blobAction.Delete.DaysAfterCreationGreaterThan);
             this.TierToCool = blobAction.TierToCool is null ? null : new PSDateAfterCreation((int)blobAction.TierToCool.DaysAfterCreationGreaterThan);
             TierToArchive = blobAction.TierToArchive is null ? null : new PSDateAfterCreation((int)blobAction.TierToArchive.DaysAfterCreationGreaterThan);
         }
-        public Track2.Models.ManagementPolicySnapShot ParseManagementPolicySnapShot()
+        public Track2Models.ManagementPolicySnapShot ParseManagementPolicySnapShot()
         {
 
-            Track2.Models.ManagementPolicySnapShot snapShot = new Track2.Models.ManagementPolicySnapShot();
+            Track2Models.ManagementPolicySnapShot snapShot = new Track2Models.ManagementPolicySnapShot();
 
             if (this.Delete != null)
             {
-                snapShot.Delete = new Track2.Models.DateAfterCreation(this.Delete.DaysAfterCreationGreaterThan);
+                snapShot.Delete = new Track2Models.DateAfterCreation(this.Delete.DaysAfterCreationGreaterThan);
             }
             if (this.TierToCool != null)
             {
-                snapShot.TierToCool = new Track2.Models.DateAfterCreation(this.TierToCool.DaysAfterCreationGreaterThan);
-                //snapShot.TierToCoolDaysAfterCreationGreaterThan = this.TierToCool.DaysAfterCreationGreaterThan;
+                snapShot.TierToCool = new Track2Models.DateAfterCreation(this.TierToCool.DaysAfterCreationGreaterThan);
             }
             if (this.TierToArchive != null)
             {
-                snapShot.TierToArchive = new Track2.Models.DateAfterCreation(this.TierToArchive.DaysAfterCreationGreaterThan);
-                //snapShot.TierToArchiveDaysAfterCreationGreaterThan = this.TierToArchive.DaysAfterCreationGreaterThan;
+                snapShot.TierToArchive = new Track2Models.DateAfterCreation(this.TierToArchive.DaysAfterCreationGreaterThan);
             }
 
             return snapShot;
@@ -315,29 +312,26 @@ namespace Microsoft.Azure.Commands.Management.Storage.Models
         public PSManagementPolicyVersion()
         { }
 
-        public PSManagementPolicyVersion(Track2.Models.ManagementPolicyVersion blobAction)
+        public PSManagementPolicyVersion(Track2Models.ManagementPolicyVersion blobAction)
         {
             this.Delete = blobAction.Delete is null ? null : new PSDateAfterCreation((int)blobAction.Delete.DaysAfterCreationGreaterThan);
             this.TierToCool = blobAction.TierToCool is null ? null :new PSDateAfterCreation((int)blobAction.TierToCool.DaysAfterCreationGreaterThan);
             this.TierToArchive = blobAction.TierToArchive is null ? null : new PSDateAfterCreation((int)blobAction.TierToArchive.DaysAfterCreationGreaterThan);
         }
-        public Track2.Models.ManagementPolicyVersion ParseManagementPolicyVersion()
+        public Track2Models.ManagementPolicyVersion ParseManagementPolicyVersion()
         {
-            Track2.Models.ManagementPolicyVersion policyVersion = new Track2.Models.ManagementPolicyVersion();
+            Track2Models.ManagementPolicyVersion policyVersion = new Track2Models.ManagementPolicyVersion();
             if (this.Delete != null)
             {
                 policyVersion.Delete = new DateAfterCreation(this.Delete.DaysAfterCreationGreaterThan);
-                //policyVersion.DeleteDaysAfterCreationGreaterThan = this.Delete.DaysAfterCreationGreaterThan;
             }
             if (this.TierToCool != null)
             {
                 policyVersion.TierToCool = new DateAfterCreation(this.TierToCool.DaysAfterCreationGreaterThan);
-                //policyVersion.TierToCoolDaysAfterCreationGreaterThan = this.TierToCool.DaysAfterCreationGreaterThan;
             }
             if (this.TierToArchive != null)
             {
                 policyVersion.TierToArchive = new DateAfterCreation(this.TierToArchive.DaysAfterCreationGreaterThan);
-                //policyVersion.TierToArchiveDaysAfterCreationGreaterThan = this.TierToArchive.DaysAfterCreationGreaterThan;
             }
 
             return policyVersion;
@@ -380,7 +374,7 @@ namespace Microsoft.Azure.Commands.Management.Storage.Models
             this.DaysAfterLastTierChangeGreaterThan = DaysAfterLastTierChangeGreaterThan;
         }
 
-        public PSDateAfterModification(Track2.Models.DateAfterModification data)
+        public PSDateAfterModification(Track2Models.DateAfterModification data)
         {
             if (data.DaysAfterModificationGreaterThan is null)
             {
@@ -399,9 +393,9 @@ namespace Microsoft.Azure.Commands.Management.Storage.Models
                 this.DaysAfterLastAccessTimeGreaterThan = Convert.ToInt32(data.DaysAfterLastAccessTimeGreaterThan);
             }
         }
-        public Track2.Models.DateAfterModification ParseDateAfterModification()
+        public Track2Models.DateAfterModification ParseDateAfterModification()
         {
-            Track2.Models.DateAfterModification dateAfterModification = new Track2.Models.DateAfterModification();
+            Track2Models.DateAfterModification dateAfterModification = new Track2Models.DateAfterModification();
             dateAfterModification.DaysAfterLastAccessTimeGreaterThan = this.DaysAfterLastAccessTimeGreaterThan;
             dateAfterModification.DaysAfterModificationGreaterThan = this.DaysAfterModificationGreaterThan;
             // TODO: Add DaysAfterLastTierChangeGreaterThan once supported by Track2 SDK

--- a/src/Storage/Storage.Management/Models/PSNetworkRule.cs
+++ b/src/Storage/Storage.Management/Models/PSNetworkRule.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Azure.Commands.Management.Storage.Models
 
     public struct PSResourceAccessRule
     {
-        public string TenantId;
+        public Guid? TenantId;
         public string ResourceId;
     }
 
@@ -201,7 +201,7 @@ namespace Microsoft.Azure.Commands.Management.Storage.Models
         {
             PSIpRule returnRule = new PSIpRule
             {
-                Action = ipRule.Action != null ? ParsePSNetworkRuleAction(ipRule.Action) : null,
+                Action = ipRule.Action != null ? ParsePSNetworkRuleAction(ipRule.Action?.ToString()) : null,
                 IPAddressOrRange = ipRule.IPAddressOrRange
             };
             return returnRule;
@@ -242,7 +242,7 @@ namespace Microsoft.Azure.Commands.Management.Storage.Models
         public static PSVirtualNetworkRule ParsePSNetworkRuleVirtualNetworkRule(Track2Models.VirtualNetworkRule virtualNetworkRule)
         {
             PSVirtualNetworkRule returnRule = new PSVirtualNetworkRule();
-            returnRule.Action = ParsePSNetworkRuleAction(virtualNetworkRule.Action);
+            returnRule.Action = ParsePSNetworkRuleAction(virtualNetworkRule.Action?.ToString());
             returnRule.VirtualNetworkResourceId = virtualNetworkRule.VirtualNetworkResourceId;
             returnRule.State = virtualNetworkRule.State.ToString();
 

--- a/src/Storage/Storage.Management/Storage.Management.csproj
+++ b/src/Storage/Storage.Management/Storage.Management.csproj
@@ -22,8 +22,8 @@
   </ItemGroup>
   <ItemGroup>
     <!-- <PackageReference Include="Azure.Core" Version="1.24.0" /> -->
-    <PackageReference Include="Azure.ResourceManager" Version="1.0.0" />
-    <PackageReference Include="Azure.ResourceManager.Storage" Version="1.0.0-beta.9" />
+    <PackageReference Include="Azure.ResourceManager" Version="1.1.1" />
+    <PackageReference Include="Azure.ResourceManager.Storage" Version="1.0.0-beta.10" />
     <PackageReference Include="Microsoft.Azure.Management.Storage" Version="24.0.0" />
     <PackageReference Include="Microsoft.Azure.Storage.Blob" Version="11.2.2" />
     <PackageReference Include="Microsoft.Azure.Storage.File" Version="11.2.2" />

--- a/src/Storage/Storage.Management/StorageAccount/AddAzureStorageAccountNetworkRule.cs
+++ b/src/Storage/Storage.Management/StorageAccount/AddAzureStorageAccountNetworkRule.cs
@@ -15,6 +15,7 @@
 using Microsoft.Azure.Commands.Management.Storage.Models;
 using Microsoft.Azure.Commands.ResourceManager.Common.ArgumentCompleters;
 using Microsoft.Azure.Commands.ResourceManager.Common.Tags;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Management.Automation;
@@ -112,7 +113,7 @@ namespace Microsoft.Azure.Commands.Management.Storage
             Mandatory = true,
             HelpMessage = "Storage Account ResourceAccessRule TenantId  in string.",
             ParameterSetName = ResourceAccessRuleStringParameterSet)]
-        public string TenantId { get; set; }
+        public Guid? TenantId { get; set; }
 
         [Parameter(
             Mandatory = true,
@@ -189,7 +190,7 @@ namespace Microsoft.Azure.Commands.Management.Storage
                         bool ResourceAccessruleExist = false;
                         foreach (Track2Models.ResourceAccessRule originRule in storageACL.ResourceAccessRules)
                         {
-                            if (originRule.TenantId.Equals(this.TenantId, System.StringComparison.InvariantCultureIgnoreCase)
+                            if (originRule.TenantId.Equals(this.TenantId)
                             && originRule.ResourceId.Equals(this.ResourceId, System.StringComparison.InvariantCultureIgnoreCase))
                             {
                                 ResourceAccessruleExist = true;
@@ -233,7 +234,7 @@ namespace Microsoft.Azure.Commands.Management.Storage
                             bool ruleExist = false;
                             foreach (Track2Models.ResourceAccessRule originRule in storageACL.ResourceAccessRules)
                             {
-                                if (originRule.TenantId.Equals(rule.TenantId, System.StringComparison.InvariantCultureIgnoreCase)
+                                if (originRule.TenantId.Equals(rule.TenantId)
                                 && originRule.ResourceId.Equals(rule.ResourceId, System.StringComparison.InvariantCultureIgnoreCase))
                                 {
                                     ruleExist = true;

--- a/src/Storage/Storage.Management/StorageAccount/GetAzureStorageBlobInventoryPolicy.cs
+++ b/src/Storage/Storage.Management/StorageAccount/GetAzureStorageBlobInventoryPolicy.cs
@@ -39,11 +39,6 @@ namespace Microsoft.Azure.Commands.Management.Storage
         /// </summary>
         private const string AccountResourceIdParameterSet = "AccountResourceId";
 
-        /// <summary>
-        /// Default policy name 
-        /// </summary>
-        private const string DefaultPolicyName = "default";
-
         [Parameter(
          Position = 0,
          Mandatory = true,

--- a/src/Storage/Storage.Management/StorageAccount/NewAzStorageBlobRangeToRestore.cs
+++ b/src/Storage/Storage.Management/StorageAccount/NewAzStorageBlobRangeToRestore.cs
@@ -14,8 +14,8 @@
 
 using Microsoft.Azure.Commands.Management.Storage.Models;
 using Microsoft.Azure.Commands.ResourceManager.Common.ArgumentCompleters;
-using Microsoft.Azure.Management.Storage;
-using Microsoft.Azure.Management.Storage.Models;
+//using Microsoft.Azure.Management.Storage;
+//using Microsoft.Azure.Management.Storage.Models;
 using System.Management.Automation;
 
 namespace Microsoft.Azure.Commands.Management.Storage

--- a/src/Storage/Storage.Management/StorageAccount/NewAzStorageBlobRangeToRestore.cs
+++ b/src/Storage/Storage.Management/StorageAccount/NewAzStorageBlobRangeToRestore.cs
@@ -14,8 +14,6 @@
 
 using Microsoft.Azure.Commands.Management.Storage.Models;
 using Microsoft.Azure.Commands.ResourceManager.Common.ArgumentCompleters;
-//using Microsoft.Azure.Management.Storage;
-//using Microsoft.Azure.Management.Storage.Models;
 using System.Management.Automation;
 
 namespace Microsoft.Azure.Commands.Management.Storage

--- a/src/Storage/Storage.Management/StorageAccount/NewAzureStorageAccount.cs
+++ b/src/Storage/Storage.Management/StorageAccount/NewAzureStorageAccount.cs
@@ -553,7 +553,7 @@ namespace Microsoft.Azure.Commands.Management.Storage
 
             Track2Models.CheckNameAvailabilityResult checkNameAvailabilityResult =
                 this.StorageClientTrack2.GetSubscription(this.SubscriptionId).CheckStorageAccountNameAvailability(
-                    new Track2Models.StorageAccountCheckNameAvailabilityContent(this.Name));
+                    new Track2Models.StorageAccountNameAvailabilityContent(this.Name));
 
             if (!checkNameAvailabilityResult.NameAvailable.Value)
             {
@@ -622,7 +622,7 @@ namespace Microsoft.Azure.Commands.Management.Storage
             {
                 if (enableAzureActiveDirectoryDomainServicesForFile != null && enableAzureActiveDirectoryDomainServicesForFile.Value)
                 {
-                    createContent.AzureFilesIdentityBasedAuthentication = new Track2Models.AzureFilesIdentityBasedAuthentication(Track2Models.DirectoryServiceOptions.Aadds);
+                    createContent.AzureFilesIdentityBasedAuthentication = new Track2Models.AzureFilesIdentityBasedAuthentication(Track2Models.DirectoryServiceOption.Aadds);
                 }
                 else if (enableActiveDirectoryDomainServicesForFile != null && enableActiveDirectoryDomainServicesForFile.Value)
                 {
@@ -639,7 +639,7 @@ namespace Microsoft.Azure.Commands.Management.Storage
                     }
 
                     createContent.AzureFilesIdentityBasedAuthentication =
-                        new Track2Models.AzureFilesIdentityBasedAuthentication(Track2Models.DirectoryServiceOptions.AD);
+                        new Track2Models.AzureFilesIdentityBasedAuthentication(Track2Models.DirectoryServiceOption.AD);
                     createContent.AzureFilesIdentityBasedAuthentication.ActiveDirectoryProperties =
                         new Track2Models.ActiveDirectoryProperties(this.ActiveDirectoryDomainName, this.ActiveDirectoryNetBiosDomainName,
                         this.ActiveDirectoryForestName, this.ActiveDirectoryDomainGuid, this.ActiveDirectoryDomainSid, this.ActiveDirectoryAzureStorageSid);
@@ -652,7 +652,7 @@ namespace Microsoft.Azure.Commands.Management.Storage
                 else
                 {
                     createContent.AzureFilesIdentityBasedAuthentication =
-                        new Track2Models.AzureFilesIdentityBasedAuthentication(Track2Models.DirectoryServiceOptions.None);
+                        new Track2Models.AzureFilesIdentityBasedAuthentication(Track2Models.DirectoryServiceOption.None);
                 }
             }
 
@@ -665,7 +665,7 @@ namespace Microsoft.Azure.Commands.Management.Storage
                 if (createContent.AzureFilesIdentityBasedAuthentication == null)
                 {
                     createContent.AzureFilesIdentityBasedAuthentication =
-                        new Track2Models.AzureFilesIdentityBasedAuthentication(Track2Models.DirectoryServiceOptions.None);
+                        new Track2Models.AzureFilesIdentityBasedAuthentication(Track2Models.DirectoryServiceOption.None);
                 }
 
                 createContent.AzureFilesIdentityBasedAuthentication.DefaultSharePermission = this.DefaultSharePermission;
@@ -676,9 +676,11 @@ namespace Microsoft.Azure.Commands.Management.Storage
             }
             if (this.EncryptionKeyTypeForQueue != null || this.EncryptionKeyTypeForTable != null || this.RequireInfrastructureEncryption.IsPresent)
             {
-
-                createContent.Encryption = new Track2Models.Encryption(Track2Models.KeySource.MicrosoftStorage);
-
+                createContent.Encryption = new Track2Models.Encryption
+                {
+                    KeySource = Track2Models.KeySource.MicrosoftStorage
+                };
+            
                 if (this.EncryptionKeyTypeForQueue != null || this.EncryptionKeyTypeForTable != null)
                 {
                     createContent.Encryption.Services = new Track2Models.EncryptionServices();
@@ -729,8 +731,10 @@ namespace Microsoft.Azure.Commands.Management.Storage
 
                 if (createContent.Encryption == null)
                 {
-                    createContent.Encryption = new Track2Models.Encryption(
-                        Track2Models.KeySource.MicrosoftStorage);
+                    createContent.Encryption = new Track2Models.Encryption
+                    {
+                        KeySource = Track2Models.KeySource.MicrosoftStorage,
+                    };
                 }
 
                 if (createContent.Encryption.Services == null)
@@ -792,7 +796,7 @@ namespace Microsoft.Azure.Commands.Management.Storage
                 createContent.ExtendedLocation = new Track2Models.ExtendedLocation
                 {
                     Name = this.EdgeZone,
-                    ExtendedLocationType = Track2Models.ExtendedLocationTypes.EdgeZone,
+                    ExtendedLocationType = Track2Models.ExtendedLocationType.EdgeZone,
                 };
             }
             if (sasExpirationPeriod != null)

--- a/src/Storage/Storage.Management/StorageAccount/RemoveAzureStorageAccountNetworkRule.cs
+++ b/src/Storage/Storage.Management/StorageAccount/RemoveAzureStorageAccountNetworkRule.cs
@@ -15,7 +15,6 @@
 using Microsoft.Azure.Commands.Management.Storage.Models;
 using Microsoft.Azure.Commands.ResourceManager.Common.ArgumentCompleters;
 using Microsoft.Azure.Commands.ResourceManager.Common.Tags;
-using Microsoft.Azure.Management.WebSites.Version2016_09_01.Models;
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -249,7 +248,7 @@ namespace Microsoft.Azure.Commands.Management.Storage
         {
             foreach (Track2Models.ResourceAccessRule rule in ruleList)
             {
-                if (rule.TenantId.ToString().Equals(ruleToRemove.TenantId.ToString(), System.StringComparison.InvariantCultureIgnoreCase)
+                if (rule.TenantId.Equals(ruleToRemove.TenantId)
                    && rule.ResourceId.Equals(ruleToRemove.ResourceId, System.StringComparison.InvariantCultureIgnoreCase))
                 {
                     ruleList.Remove(rule);

--- a/src/Storage/Storage.Management/StorageAccount/RemoveAzureStorageAccountNetworkRule.cs
+++ b/src/Storage/Storage.Management/StorageAccount/RemoveAzureStorageAccountNetworkRule.cs
@@ -15,6 +15,7 @@
 using Microsoft.Azure.Commands.Management.Storage.Models;
 using Microsoft.Azure.Commands.ResourceManager.Common.ArgumentCompleters;
 using Microsoft.Azure.Commands.ResourceManager.Common.Tags;
+using Microsoft.Azure.Management.WebSites.Version2016_09_01.Models;
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -114,7 +115,7 @@ namespace Microsoft.Azure.Commands.Management.Storage
             Mandatory = true,
             HelpMessage = "Storage Account ResourceAccessRule TenantId  in string.",
             ParameterSetName = ResourceAccessRuleStringParameterSet)]
-        public string TenantId { get; set; }
+        public Guid? TenantId { get; set; }
 
         [Parameter(
             Mandatory = true,
@@ -248,7 +249,7 @@ namespace Microsoft.Azure.Commands.Management.Storage
         {
             foreach (Track2Models.ResourceAccessRule rule in ruleList)
             {
-                if (rule.TenantId.Equals(ruleToRemove.TenantId, System.StringComparison.InvariantCultureIgnoreCase)
+                if (rule.TenantId.ToString().Equals(ruleToRemove.TenantId.ToString(), System.StringComparison.InvariantCultureIgnoreCase)
                    && rule.ResourceId.Equals(ruleToRemove.ResourceId, System.StringComparison.InvariantCultureIgnoreCase))
                 {
                     ruleList.Remove(rule);

--- a/src/Storage/Storage.Management/StorageAccount/RemoveAzureStorageBlobInventoryPolicy.cs
+++ b/src/Storage/Storage.Management/StorageAccount/RemoveAzureStorageBlobInventoryPolicy.cs
@@ -114,7 +114,7 @@ namespace Microsoft.Azure.Commands.Management.Storage
                         // For AccountNameParameterSet, the ResourceGroupName and StorageAccountName can get from input directly
                         break;
                 }
-                this.StorageClientTrack2.GetBlobInventoryPolicyResource(this.ResourceGroupName, this.StorageAccountName, "default").Delete(WaitUntil.Completed);
+                this.StorageClientTrack2.GetBlobInventoryPolicyResource(this.ResourceGroupName, this.StorageAccountName, DefaultPolicyName).Delete(WaitUntil.Completed);
 
                 if (PassThru.IsPresent)
                 {

--- a/src/Storage/Storage.Management/StorageAccount/SetAzureStorageAccount.cs
+++ b/src/Storage/Storage.Management/StorageAccount/SetAzureStorageAccount.cs
@@ -580,7 +580,7 @@ namespace Microsoft.Azure.Commands.Management.Storage
                                     }
                                 }
                             }
-                        }
+                        } 
                     }
 
                     if (StorageEncryption || ParameterSetName == KeyvaultEncryptionParameterSet || this.KeyVaultUserAssignedIdentityId != null)
@@ -619,13 +619,13 @@ namespace Microsoft.Azure.Commands.Management.Storage
                             var originStorageAccount = this.StorageClientTrack2.GetSingleStorageAccount(this.ResourceGroupName, this.Name);
 
                             if (originStorageAccount.Data.AzureFilesIdentityBasedAuthentication != null
-                                && originStorageAccount.Data.AzureFilesIdentityBasedAuthentication.DirectoryServiceOptions == Track2Models.DirectoryServiceOptions.AD)
+                                && originStorageAccount.Data.AzureFilesIdentityBasedAuthentication.DirectoryServiceOptions == Track2Models.DirectoryServiceOption.AD)
                             {
                                 throw new System.ArgumentException("The Storage account already enabled ActiveDirectoryDomainServicesForFile, please disable it by run this cmdlets with \"-EnableActiveDirectoryDomainServicesForFile $false\" before enable AzureActiveDirectoryDomainServicesForFile.");
                             }
 
                             storageAccountPatch.AzureFilesIdentityBasedAuthentication =
-                                new Track2Models.AzureFilesIdentityBasedAuthentication(Track2Models.DirectoryServiceOptions.Aadds);
+                                new Track2Models.AzureFilesIdentityBasedAuthentication(Track2Models.DirectoryServiceOption.Aadds);
 
                         }
                         else //Disable AADDS
@@ -635,10 +635,10 @@ namespace Microsoft.Azure.Commands.Management.Storage
                             var originStorageAccount = this.StorageClientTrack2.GetSingleStorageAccount(this.ResourceGroupName, this.Name);
 
                             if (originStorageAccount.Data.AzureFilesIdentityBasedAuthentication == null
-                                || originStorageAccount.Data.AzureFilesIdentityBasedAuthentication.DirectoryServiceOptions == Track2Models.DirectoryServiceOptions.Aadds)
+                                || originStorageAccount.Data.AzureFilesIdentityBasedAuthentication.DirectoryServiceOptions == Track2Models.DirectoryServiceOption.Aadds)
                             {
                                 storageAccountPatch.AzureFilesIdentityBasedAuthentication =
-                                    new Track2Models.AzureFilesIdentityBasedAuthentication(Track2Models.DirectoryServiceOptions.None);
+                                    new Track2Models.AzureFilesIdentityBasedAuthentication(Track2Models.DirectoryServiceOption.None);
                             }
                             else
                             {
@@ -671,13 +671,13 @@ namespace Microsoft.Azure.Commands.Management.Storage
 
 
                             if (originStorageAccount.Data.AzureFilesIdentityBasedAuthentication != null
-                                && originStorageAccount.Data.AzureFilesIdentityBasedAuthentication.DirectoryServiceOptions == Track2Models.DirectoryServiceOptions.Aadds)
+                                && originStorageAccount.Data.AzureFilesIdentityBasedAuthentication.DirectoryServiceOptions == Track2Models.DirectoryServiceOption.Aadds)
                             {
                                 throw new System.ArgumentException("The Storage account already enabled AzureActiveDirectoryDomainServicesForFile, please disable it by run this cmdlets with \"-EnableAzureActiveDirectoryDomainServicesForFile $false\" before enable ActiveDirectoryDomainServicesForFile.");
                             }
 
                             storageAccountPatch.AzureFilesIdentityBasedAuthentication =
-                                new Track2Models.AzureFilesIdentityBasedAuthentication(Track2Models.DirectoryServiceOptions.AD);
+                                new Track2Models.AzureFilesIdentityBasedAuthentication(Track2Models.DirectoryServiceOption.AD);
 
                             storageAccountPatch.AzureFilesIdentityBasedAuthentication.ActiveDirectoryProperties =
                                 new Track2Models.ActiveDirectoryProperties(this.ActiveDirectoryDomainName, this.ActiveDirectoryNetBiosDomainName,
@@ -707,10 +707,10 @@ namespace Microsoft.Azure.Commands.Management.Storage
                             var originStorageAccount = this.StorageClientTrack2.GetSingleStorageAccount(this.ResourceGroupName, this.Name);
 
                             if (originStorageAccount.Data.AzureFilesIdentityBasedAuthentication == null
-                                || originStorageAccount.Data.AzureFilesIdentityBasedAuthentication.DirectoryServiceOptions == Track2Models.DirectoryServiceOptions.AD)
+                                || originStorageAccount.Data.AzureFilesIdentityBasedAuthentication.DirectoryServiceOptions == Track2Models.DirectoryServiceOption.AD)
                             {
                                 storageAccountPatch.AzureFilesIdentityBasedAuthentication =
-                                    new Track2Models.AzureFilesIdentityBasedAuthentication(Track2Models.DirectoryServiceOptions.None);
+                                    new Track2Models.AzureFilesIdentityBasedAuthentication(Track2Models.DirectoryServiceOption.None);
 
                             }
                             else
@@ -726,7 +726,7 @@ namespace Microsoft.Azure.Commands.Management.Storage
                         {
                             storageAccountPatch.AzureFilesIdentityBasedAuthentication =
                                 new Track2Models.AzureFilesIdentityBasedAuthentication(
-                                    Track2Models.DirectoryServiceOptions.None);
+                                    Track2Models.DirectoryServiceOption.None);
                         }
 
                         storageAccountPatch.AzureFilesIdentityBasedAuthentication.DefaultSharePermission = this.DefaultSharePermission;

--- a/src/Storage/Storage.Management/StorageAccount/SetAzureStorageBlobInventoryPolicy.cs
+++ b/src/Storage/Storage.Management/StorageAccount/SetAzureStorageBlobInventoryPolicy.cs
@@ -199,14 +199,14 @@ namespace Microsoft.Azure.Commands.Management.Storage
                             Track2Models.InventoryRuleType.Inventory,
                             PSBlobInventoryPolicy.ParseBlobInventoryPolicyRules(this.Rule));
                         blobInventoryPolicyResource = this.StorageClientTrack2
-                            .GetBlobInventoryPolicyResource(this.ResourceGroupName, this.StorageAccountName, "default")
+                            .GetBlobInventoryPolicyResource(this.ResourceGroupName, this.StorageAccountName, DefaultPolicyName)
                             .Update(WaitUntil.Completed, data).Value;
                         break;
                     case AccountObjectPolicyObjectParameterSet:
                     case AccountNamePolicyObjectParameterSet:
                     case AccountResourceIdPolicyObjectParameterSet:
                         blobInventoryPolicyResource = this.StorageClientTrack2
-                            .GetBlobInventoryPolicyResource(this.ResourceGroupName, this.StorageAccountName, "default")
+                            .GetBlobInventoryPolicyResource(this.ResourceGroupName, this.StorageAccountName, DefaultPolicyName)
                             .Update(WaitUntil.Completed, this.Policy.ParseBlobInventoryPolicy()).Value;
                         break;
                     default:

--- a/src/Storage/Storage.Management/StorageAccount/StorageAccountBaseCmdlet.cs
+++ b/src/Storage/Storage.Management/StorageAccount/StorageAccountBaseCmdlet.cs
@@ -61,6 +61,8 @@ namespace Microsoft.Azure.Commands.Management.Storage
         internal const string StandardGZRS = "Standard_GZRS";
         internal const string StandardRAGZRS = "Standard_RAGZRS";
 
+        protected const string DefaultPolicyName = "default";
+
         protected struct AccountAccessTier
         {
             internal const string Hot = "Hot";
@@ -197,9 +199,7 @@ namespace Microsoft.Azure.Commands.Management.Storage
 
         protected static Track2Models.Encryption ParseEncryption(bool storageEncryption = false, bool keyVaultEncryption = false, string keyName = null, string keyVersion = null, string keyVaultUri = null)
         {
-            // TODO: Fix the KeySource value. It should be null or empty. Input KeyVault for a placeholder.
-            Track2Models.Encryption accountEncryption =
-                new Track2Models.Encryption(Track2Models.KeySource.MicrosoftKeyvault);
+            Track2Models.Encryption accountEncryption = new Track2Models.Encryption();
 
             if (storageEncryption)
             {

--- a/src/Storage/Storage.Management/Track2StorageManagementClient.cs
+++ b/src/Storage/Storage.Management/Track2StorageManagementClient.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Azure.Commands.Management.Storage
         /// <summary>
         /// Check if a storage account name is available
         /// </summary>
-        public CheckNameAvailabilityResult CheckNameAvailability(StorageAccountCheckNameAvailabilityContent content) =>
+        public CheckNameAvailabilityResult CheckNameAvailability(StorageAccountNameAvailabilityContent content) =>
             GetSubscription(_subscription).CheckStorageAccountNameAvailability(content);
 
         /// <summary>

--- a/tools/Common.Netcore.Dependencies.targets
+++ b/tools/Common.Netcore.Dependencies.targets
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <PackageReference Include="Azure.ResourceManager" Version="1.0.0" />
+    <PackageReference Include="Azure.ResourceManager" Version="1.1.1" />
     <PackageReference Include="Microsoft.Azure.PowerShell.Clients.Aks" Version="1.0.0-preview"/>
     <PackageReference Include="Microsoft.Azure.PowerShell.Authentication.Abstractions" Version="1.0.0-preview"/>
     <PackageReference Include="Microsoft.Azure.PowerShell.Clients.Authorization" Version="1.0.0-preview"/>


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
This PR includes changes for upgrading the Track2 migration code to SDK version of 1.0.0-beta.10. This also requires to upgrade Azure.ResourceManager to 1.1.1.

There's one breaking change in this PR:
In network rule related cmdlets, TenantId <string> is changed to TenantId <Guid>.
<!-- Please add a brief description of the changes made in this PR -->

## Checklist

- [x] I have read the [_Submitting Changes_](../blob/master/CONTRIBUTING.md#submitting-changes) section of [`CONTRIBUTING.md`](../blob/master/CONTRIBUTING.md)
- [x] The title of the PR is clear and informative
- [ ] The appropriate `ChangeLog.md` file(s) has been updated:
    - For any service, the `ChangeLog.md` file can be found at `src/{{SERVICE}}/{{SERVICE}}/ChangeLog.md`
    - A snippet outlining the change(s) made in the PR should be written under the `## Upcoming Release` header -- no new version header should be added
- [ ] The PR does not introduce [breaking changes](../blob/master/documentation/breaking-changes/breaking-changes-definition.md)
- [ ] If applicable, the changes made in the PR have proper test coverage
- [ ] For public API changes to cmdlets:
    - [ ] a cmdlet design review was approved for the changes in [this repository](https://github.com/Azure/azure-powershell-cmdlet-review-pr) (_Microsoft internal only_)
    - [ ] the markdown help files have been regenerated using the commands listed [here](../blob/master/documentation/development-docs/help-generation.md#updating-all-markdown-files-in-a-module)
