### PR TITLE
Migrate EncryptionScope and ObjectReplication cmdlets to Track2 SDK

### DIFF
--- a/src/Storage/Storage.Management/File/StorageFileBaseCmdlet.cs
+++ b/src/Storage/Storage.Management/File/StorageFileBaseCmdlet.cs
@@ -16,7 +16,6 @@ using Microsoft.Azure.Commands.Management.Storage.Models;
 using Microsoft.Azure.Commands.ResourceManager.Common;
 using Microsoft.Azure.Management.Storage;
 using Microsoft.Azure.Management.Storage.Models;
-using Microsoft.Azure.Management.WebSites.Version2016_09_01.Models;
 using Microsoft.WindowsAzure.Commands.Utilities.Common;
 using System;
 using System.Collections;

--- a/src/Storage/Storage.Management/File/StorageFileBaseCmdlet.cs
+++ b/src/Storage/Storage.Management/File/StorageFileBaseCmdlet.cs
@@ -16,11 +16,11 @@ using Microsoft.Azure.Commands.Management.Storage.Models;
 using Microsoft.Azure.Commands.ResourceManager.Common;
 using Microsoft.Azure.Management.Storage;
 using Microsoft.Azure.Management.Storage.Models;
+using Microsoft.Azure.Management.WebSites.Version2016_09_01.Models;
 using Microsoft.WindowsAzure.Commands.Utilities.Common;
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using StorageModels = Microsoft.Azure.Management.Storage.Models;
 
 namespace Microsoft.Azure.Commands.Management.Storage
 {
@@ -85,6 +85,33 @@ namespace Microsoft.Azure.Commands.Management.Storage
             internal const string Snapshots = "snapshots";
         }
 
+        protected struct RootSquashType
+        {
+            internal const string NoRootSquash = "NoRootSquash";
+            internal const string RootSquash = "RootSquash";
+            internal const string AllSquash = "AllSquash";
+        }
+
+        protected struct ShareAccessTier
+        {
+            internal const string TransactionOptimized = "TransactionOptimized";
+            internal const string Hot = "Hot";
+            internal const string Cool = "Cool";
+            internal const string Premium = "Premium";
+        }
+
+        protected struct EncryptionScopeState
+        {
+            internal const string Enabled = "Enabled";
+            internal const string Disabled = "Disabled";
+        }
+
+        protected struct EnabledProtocols
+        {
+            internal const string SMB = "SMB";
+            internal const string NFS = "NFS";
+        }
+
         public string ConnectStringArray(string[] stringArray, string seperator = ";")
         {
             if (stringArray == null)
@@ -121,6 +148,19 @@ namespace Microsoft.Azure.Commands.Management.Storage
             }
 
             set { storageClientWrapper = new StorageManagementClientWrapper(value); }
+        }
+
+        private Track2StorageManagementClient _track2StorageManagementClient;
+        public Track2StorageManagementClient StorageClientTrack2
+        {
+            get
+            {
+                return _track2StorageManagementClient ?? (_track2StorageManagementClient = new Track2StorageManagementClient(
+                    Microsoft.Azure.Commands.Common.Authentication.AzureSession.Instance.ClientFactory,
+                    DefaultContext));
+            }
+
+            set { _track2StorageManagementClient = value; }
         }
 
         public string SubscriptionId

--- a/src/Storage/Storage.Management/Models/PSEncryptionScope.cs
+++ b/src/Storage/Storage.Management/Models/PSEncryptionScope.cs
@@ -13,34 +13,34 @@
 // ----------------------------------------------------------------------------------
 
 using Microsoft.Azure.Commands.Common.Authentication.Abstractions;
-using Microsoft.Azure.Management.Storage;
-using Microsoft.Azure.Management.Storage.Models;
 using Microsoft.WindowsAzure.Commands.Common.Attributes;
 using Microsoft.WindowsAzure.Commands.Common.Storage;
 using Microsoft.WindowsAzure.Commands.Storage.Adapters;
 using Microsoft.Azure.Storage;
 using System;
 using System.Collections.Generic;
-using StorageModels = Microsoft.Azure.Management.Storage.Models;
+using Track2 = Azure.ResourceManager.Storage;
+using Track2Models = Azure.ResourceManager.Storage.Models;
+
 
 namespace Microsoft.Azure.Commands.Management.Storage.Models
 {
     // wrapper of EncryptionScope
     public class PSEncryptionScope
     {
-        public PSEncryptionScope(StorageModels.EncryptionScope scope)
+        public PSEncryptionScope(Track2.EncryptionScopeResource scope)
         {
             this.ResourceGroupName = ParseResourceGroupFromId(scope.Id);
             this.StorageAccountName = ParseStorageAccountNameFromId(scope.Id);
             this.Id = scope.Id;
-            this.Name = scope.Name;
-            this.Type = scope.Type;
-            this.LastModifiedTime = scope.LastModifiedTime;
-            this.CreationTime = scope.CreationTime;
-            this.Source = scope.Source;
-            this.State = scope.State;
-            this.KeyVaultProperties = scope.KeyVaultProperties is null ? null : new PSEncryptionScopeKeyVaultProperties(scope.KeyVaultProperties);
-            this.RequireInfrastructureEncryption = scope.RequireInfrastructureEncryption;
+            this.Name = scope.Data.Name;
+            this.Type = scope.Data.ResourceType;
+            this.LastModifiedTime = scope.Data.LastModifiedOn;
+            this.CreationTime = scope.Data.CreationOn;
+            this.Source = scope.Data.Source.ToString();
+            this.State = scope.Data.State.ToString();
+            this.KeyVaultProperties = scope.Data.KeyVaultProperties is null ? null : new PSEncryptionScopeKeyVaultProperties(scope.Data.KeyVaultProperties);
+            this.RequireInfrastructureEncryption = scope.Data.RequireInfrastructureEncryption;
         }
 
         [Ps1Xml(Label = "ResourceGroupName", Target = ViewControl.List, Position = 0)]
@@ -65,9 +65,9 @@ namespace Microsoft.Azure.Commands.Management.Storage.Models
         public bool? RequireInfrastructureEncryption { get; set; }
 
         [Ps1Xml(Label = "LastModifiedTime", Target = ViewControl.List, Position = 4)]
-        public DateTime? LastModifiedTime { get; set; }
+        public DateTimeOffset? LastModifiedTime { get; set; }
 
-        public DateTime? CreationTime { get; set; }
+        public DateTimeOffset? CreationTime { get; set; }
 
         public static string ParseResourceGroupFromId(string idFromServer)
         {
@@ -98,11 +98,14 @@ namespace Microsoft.Azure.Commands.Management.Storage.Models
     //wrapper of EncryptionScopeKeyVaultProperties
     public class PSEncryptionScopeKeyVaultProperties
     {
-        public PSEncryptionScopeKeyVaultProperties(StorageModels.EncryptionScopeKeyVaultProperties keyVaultProperties)
+        public PSEncryptionScopeKeyVaultProperties(Track2Models.EncryptionScopeKeyVaultProperties keyVaultProperties)
         {
             if (keyVaultProperties != null)
             {
-                this.keyUri = keyVaultProperties.KeyUri;
+                if (keyVaultProperties.KeyUri != null)
+                {
+                    this.keyUri = keyVaultProperties.KeyUri.OriginalString;
+                }
             }
         }
 

--- a/src/Storage/Storage.Management/Models/PSEncryptionScope.cs
+++ b/src/Storage/Storage.Management/Models/PSEncryptionScope.cs
@@ -22,7 +22,6 @@ using System.Collections.Generic;
 using Track2 = Azure.ResourceManager.Storage;
 using Track2Models = Azure.ResourceManager.Storage.Models;
 
-
 namespace Microsoft.Azure.Commands.Management.Storage.Models
 {
     // wrapper of EncryptionScope

--- a/src/Storage/Storage.Management/Models/PSObjectReplicationPolicy.cs
+++ b/src/Storage/Storage.Management/Models/PSObjectReplicationPolicy.cs
@@ -72,7 +72,6 @@ namespace Microsoft.Azure.Commands.Management.Storage.Models
             {
                 data.Rules.Add(rule.ParseObjectReplicationPolicyRule());
             }
-
             return data;
         }
     }
@@ -143,7 +142,6 @@ namespace Microsoft.Azure.Commands.Management.Storage.Models
             if (filter != null)
             {
                 this.PrefixMatch = filter.PrefixMatch is null ? null : new List<string>(filter.PrefixMatch).ToArray();
-
                 if (filter.MinCreationTime != null)
                 {
                     if (filter.MinCreationTime.ToUpper()[filter.MinCreationTime.Length - 1] != 'Z')
@@ -154,7 +152,6 @@ namespace Microsoft.Azure.Commands.Management.Storage.Models
                 }
             }
         }
- 
 
         public Track2Models.ObjectReplicationPolicyFilter ParseObjectReplicationPolicyFilter()
         {

--- a/src/Storage/Storage.Management/StorageAccount/GetAzStorageObjectReplicationPolicy.cs
+++ b/src/Storage/Storage.Management/StorageAccount/GetAzStorageObjectReplicationPolicy.cs
@@ -82,7 +82,6 @@ namespace Microsoft.Azure.Commands.Management.Storage
             }
             if (!string.IsNullOrEmpty(PolicyId))
             {
-
                 Track2.ObjectReplicationPolicyResource policy = this.StorageClientTrack2
                     .GetObjectReplicationPolicyResource(this.ResourceGroupName, this.StorageAccountName, this.PolicyId)
                     .Get();
@@ -102,7 +101,6 @@ namespace Microsoft.Azure.Commands.Management.Storage
                 {
                     pspolicies.Add(new PSObjectReplicationPolicy(policy, this.ResourceGroupName, this.StorageAccountName));
                 }
-               
                 WriteObject(pspolicies.ToArray(), true);
             }
         }

--- a/src/Storage/Storage.Management/StorageAccount/NewAzStorageObjectReplicationPolicyRule.cs
+++ b/src/Storage/Storage.Management/StorageAccount/NewAzStorageObjectReplicationPolicyRule.cs
@@ -40,18 +40,18 @@ namespace Microsoft.Azure.Commands.Management.Storage
 
         [Parameter(Mandatory = false, HelpMessage = "Blobs created after the time will be replicated to the destination..")]
         [ValidateNotNull]
-        public DateTime MinCreationTime
+        public DateTimeOffset MinCreationTime
         {
             get
             {
-                return minCreationTime is null ? DateTime.MinValue : minCreationTime.Value;
+                return minCreationTime is null ? DateTimeOffset.MinValue : minCreationTime.Value;
             }
             set
             {
                 minCreationTime = value;
             }
         }
-        private DateTime? minCreationTime;
+        private DateTimeOffset? minCreationTime;
 
         [Parameter(Mandatory = false,
             HelpMessage = "Object Replication Rule Id.")]

--- a/src/Storage/Storage.Management/StorageAccount/NewAzureStorageEncryptionScope.cs
+++ b/src/Storage/Storage.Management/StorageAccount/NewAzureStorageEncryptionScope.cs
@@ -13,13 +13,13 @@
 // ----------------------------------------------------------------------------------
 
 using Microsoft.Azure.Commands.Management.Storage.Models;
-using Microsoft.Azure.Management.Storage;
-using Microsoft.Azure.Management.Storage.Models;
 using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Management.Automation;
 using Microsoft.Azure.Management.Internal.Resources.Utilities.Models;
+using Track2 = Azure.ResourceManager.Storage;
+using Track2Models = Azure.ResourceManager.Storage.Models;
 
 namespace Microsoft.Azure.Commands.Management.Storage
 {
@@ -138,26 +138,29 @@ namespace Microsoft.Azure.Commands.Management.Storage
                         break;
                 }
 
-                EncryptionScope scope = new EncryptionScope();
+                Track2.EncryptionScopeData data = new Track2.EncryptionScopeData();
                 if (this.KeyvaultEncryption.IsPresent)
                 {
-                    scope.Source = EncryptionScopeSource.MicrosoftKeyVault;
-                    scope.KeyVaultProperties = new EncryptionScopeKeyVaultProperties(this.KeyUri);
+                    data.Source = Track2Models.EncryptionScopeSource.MicrosoftKeyVault;
+                    data.KeyVaultProperties = new Track2Models.EncryptionScopeKeyVaultProperties
+                    {
+                        KeyUri = new Uri(this.KeyUri)
+                    };
+
                 }
                 else
                 {
-                    scope.Source = EncryptionScopeSource.MicrosoftStorage;
+                    data.Source = Track2Models.EncryptionScopeSource.MicrosoftStorage;
                 }
                 if (this.RequireInfrastructureEncryption.IsPresent)
                 {
-                    scope.RequireInfrastructureEncryption = true;
+                    data.RequireInfrastructureEncryption = true;
                 }
 
-                scope = this.StorageClient.EncryptionScopes.Put(
-                            this.ResourceGroupName,
-                            this.StorageAccountName,
-                            this.EncryptionScopeName,
-                            scope);
+                Track2.EncryptionScopeResource scope = this.StorageClientTrack2
+                    .GetStorageAccount(this.ResourceGroupName, this.StorageAccountName)
+                    .GetEncryptionScopes()
+                    .CreateOrUpdate(global::Azure.WaitUntil.Completed, this.EncryptionScopeName, data).Value ;
 
                 WriteObject(new PSEncryptionScope(scope));
             }

--- a/src/Storage/Storage.Management/StorageAccount/RemoveAzStorageObjectReplicationPolicy.cs
+++ b/src/Storage/Storage.Management/StorageAccount/RemoveAzStorageObjectReplicationPolicy.cs
@@ -14,7 +14,6 @@
 
 using Microsoft.Azure.Commands.Management.Storage.Models;
 using Microsoft.Azure.Commands.ResourceManager.Common.ArgumentCompleters;
-using Microsoft.Azure.Management.Storage;
 using System.Management.Automation;
 
 namespace Microsoft.Azure.Commands.Management.Storage
@@ -106,10 +105,8 @@ namespace Microsoft.Azure.Commands.Management.Storage
                         break;
                 }
 
-                this.StorageClient.ObjectReplicationPolicies.Delete(
-                     this.ResourceGroupName,
-                     this.StorageAccountName,
-                     PolicyId);
+                this.StorageClientTrack2.GetObjectReplicationPolicyResource(this.ResourceGroupName, this.StorageAccountName, this.PolicyId)
+                    .Delete(global::Azure.WaitUntil.Completed);
 
                 if (PassThru.IsPresent)
                 {

--- a/src/Storage/Storage.Management/StorageAccount/RemoveAzStorageObjectReplicationPolicy.cs
+++ b/src/Storage/Storage.Management/StorageAccount/RemoveAzStorageObjectReplicationPolicy.cs
@@ -104,7 +104,6 @@ namespace Microsoft.Azure.Commands.Management.Storage
                         // For AccountNameParameterSet, the ResourceGroupName and StorageAccountName can get from input directly
                         break;
                 }
-
                 this.StorageClientTrack2.GetObjectReplicationPolicyResource(this.ResourceGroupName, this.StorageAccountName, this.PolicyId)
                     .Delete(global::Azure.WaitUntil.Completed);
 

--- a/src/Storage/Storage.Management/StorageAccount/SetAzStorageObjectReplicationPolicy.cs
+++ b/src/Storage/Storage.Management/StorageAccount/SetAzStorageObjectReplicationPolicy.cs
@@ -142,7 +142,6 @@ namespace Microsoft.Azure.Commands.Management.Storage
             if (ShouldProcess(this.StorageAccountName, "Set Storage Account Object Replication Policy"))
             {
                 Track2.ObjectReplicationPolicyData data = new Track2.ObjectReplicationPolicyData();
-
                 switch (ParameterSetName)
                 {
                     case AccountObjectParameterSet:
@@ -152,7 +151,6 @@ namespace Microsoft.Azure.Commands.Management.Storage
                     case PolicyObjectParameterSet:
                         this.PolicyId = InputObject.PolicyId;
                         data = InputObject.ParseObjectReplicationPolicy();
-
                         break;
                     default:
                         // For AccountNameParameterSet, the ResourceGroupName and StorageAccountName can get from input directly

--- a/src/Storage/Storage.Management/StorageAccount/UpdateAzureStorageEncryptionScope.cs
+++ b/src/Storage/Storage.Management/StorageAccount/UpdateAzureStorageEncryptionScope.cs
@@ -189,7 +189,6 @@ namespace Microsoft.Azure.Commands.Management.Storage
                 }
 
                 Track2.EncryptionScopeData data = new Track2.EncryptionScopeData();
-
                 if (this.KeyvaultEncryption.IsPresent)
                 {
                     data.Source = Track2Models.EncryptionScopeSource.MicrosoftKeyVault;

--- a/src/Storage/Storage.Management/StorageAccount/UpdateAzureStorageEncryptionScope.cs
+++ b/src/Storage/Storage.Management/StorageAccount/UpdateAzureStorageEncryptionScope.cs
@@ -13,13 +13,13 @@
 // ----------------------------------------------------------------------------------
 
 using Microsoft.Azure.Commands.Management.Storage.Models;
-using Microsoft.Azure.Management.Storage;
-using Microsoft.Azure.Management.Storage.Models;
 using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Management.Automation;
 using Microsoft.Azure.Management.Internal.Resources.Utilities.Models;
+using Track2 = Azure.ResourceManager.Storage;
+using Track2Models = Azure.ResourceManager.Storage.Models;
 
 namespace Microsoft.Azure.Commands.Management.Storage
 {
@@ -188,34 +188,36 @@ namespace Microsoft.Azure.Commands.Management.Storage
                         break;
                 }
 
-                EncryptionScope scope = new EncryptionScope();
+                Track2.EncryptionScopeData data = new Track2.EncryptionScopeData();
+
                 if (this.KeyvaultEncryption.IsPresent)
                 {
-                    scope.Source = EncryptionScopeSource.MicrosoftKeyVault;
-                    scope.KeyVaultProperties = new EncryptionScopeKeyVaultProperties(this.KeyUri);
+                    data.Source = Track2Models.EncryptionScopeSource.MicrosoftKeyVault;
+                    data.KeyVaultProperties = new Track2Models.EncryptionScopeKeyVaultProperties
+                    {
+                        KeyUri = new Uri(this.KeyUri)
+                    };
                 }
                 if (this.StorageEncryption.IsPresent)
                 {
-                    scope.Source = EncryptionScopeSource.MicrosoftStorage;
+                    data.Source = Track2Models.EncryptionScopeSource.MicrosoftStorage;
                 }
 
                 if (this.State != null)
                 {
                     if (this.State.Equals(EncryptionScopeState.Enabled, StringComparison.CurrentCultureIgnoreCase))
                     {
-                        scope.State = EncryptionScopeState.Enabled;
+                        data.State = Track2Models.EncryptionScopeState.Enabled;
                     }
                     if (this.State.Equals(EncryptionScopeState.Disabled, StringComparison.CurrentCultureIgnoreCase))
                     {
-                        scope.State = EncryptionScopeState.Disabled;
+                        data.State = Track2Models.EncryptionScopeState.Disabled;
                     }
                 }
 
-                scope = this.StorageClient.EncryptionScopes.Patch(
-                            this.ResourceGroupName,
-                            this.StorageAccountName,
-                            this.EncryptionScopeName,
-                            scope);
+                Track2.EncryptionScopeResource scope = this.StorageClientTrack2
+                    .GetEncryptionScopeResource(this.ResourceGroupName, this.StorageAccountName, this.EncryptionScopeName)
+                    .Update(data);
 
                 WriteObject(new PSEncryptionScope(scope));
             }


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
This PR includes migration of EncryptionScope and ObjectReplication related cmdlets. 
<!-- Please add a brief description of the changes made in this PR -->

## Checklist

- [ ] I have read the [_Submitting Changes_](../blob/master/CONTRIBUTING.md#submitting-changes) section of [`CONTRIBUTING.md`](../blob/master/CONTRIBUTING.md)
- [ ] The title of the PR is clear and informative
- [ ] The appropriate `ChangeLog.md` file(s) has been updated:
    - For any service, the `ChangeLog.md` file can be found at `src/{{SERVICE}}/{{SERVICE}}/ChangeLog.md`
    - A snippet outlining the change(s) made in the PR should be written under the `## Upcoming Release` header -- no new version header should be added
- [ ] The PR does not introduce [breaking changes](../blob/master/documentation/breaking-changes/breaking-changes-definition.md)
- [ ] If applicable, the changes made in the PR have proper test coverage
- [ ] For public API changes to cmdlets:
    - [ ] a cmdlet design review was approved for the changes in [this repository](https://github.com/Azure/azure-powershell-cmdlet-review-pr) (_Microsoft internal only_)
    - [ ] the markdown help files have been regenerated using the commands listed [here](../blob/master/documentation/development-docs/help-generation.md#updating-all-markdown-files-in-a-module)
