### PR TITLE
Some test fix

### DIFF
--- a/src/Storage/RegressionTests/adls.ps1
+++ b/src/Storage/RegressionTests/adls.ps1
@@ -3,7 +3,7 @@
 
 BeforeAll {
     # Modify the path to your own
-    Import-Module D:\code\azure-powershell\src\Storage\RegressionTests\utils.ps1
+    Import-Module $PSScriptRoot\utils.ps1
 
     [xml]$config = Get-Content D:\code\azure-powershell\src\Storage\RegressionTests\config.xml
     $globalNode = $config.SelectSingleNode("config/section[@id='global']")

--- a/src/Storage/RegressionTests/dataplane.ps1
+++ b/src/Storage/RegressionTests/dataplane.ps1
@@ -2,7 +2,7 @@
 
 BeforeAll {
     # Modify the path to your own
-    Import-Module D:\code\azure-powershell\src\Storage\RegressionTests\utils.ps1
+    Import-Module $PSScriptRoot\utils.ps1
 
     [xml]$config = Get-Content D:\code\azure-powershell\src\Storage\RegressionTests\config.xml
     $globalNode = $config.SelectSingleNode("config/section[@id='global']")
@@ -181,9 +181,13 @@ Describe "dataplane test" {
         $sas = New-AzStorageBlobSASToken -container $containerName -Blob test.txt -Permission w -Context $ctx
         $ctxsas = New-AzStorageContext -StorageAccountName $ctx.StorageAccountName -SasToken $sas.Substring(1)
         $bs = Get-AzStorageBlob -Container $containerName -Context $ctx
+        $bs[0].ListBlobProperties | should -Not -Be $null
+        $bs[0].ListBlobProperties.Properties | should -Not -Be $null
+        $bs[0].ListBlobProperties.Properties.BlobType | should -Not -Be $null
         $bs[0].BlobProperties | should -Not -Be $null
         $b = Get-AzStorageBlob -Container $containerName -Blob $bs[0].Name -Context $ctx
         $b.BlobProperties | should -Not -Be $null
+        $b.ListBlobProperties | should -Be $null
 
         #copy with oauth 
         # cross account     

--- a/src/Storage/RegressionTests/runStable.ps1
+++ b/src/Storage/RegressionTests/runStable.ps1
@@ -1,21 +1,21 @@
 ﻿
 
-Import-Module d:\code\PSH_Dev\artifacts\Debug\Az.Accounts\Az.Accounts.psd1
-Import-Module d:\code\PSH_Dev\artifacts\Debug\Az.Storage\Az.Storage.psd1
+#Import-Module d:\code\PSH_Dev\artifacts\Debug\Az.Accounts\Az.Accounts.psd1
+#Import-Module d:\code\PSH_Dev\artifacts\Debug\Az.Storage\Az.Storage.psd1
 
 
-Import-Module C:\Users\weiwei\Desktop\PSH_Script\PSHTest\utils.ps1
-Import-Module C:\Users\weiwei\Desktop\PSH_Script\Assert.ps1
+Import-Module $PSScriptRoot\utils.ps1
+# Import-Module $PSScriptRoot\Assert.ps1
 
 
 # $preview = $true
 
-Invoke-Pester C:\Users\weiwei\Desktop\PSH_Script\PSHTest\dataplane.ps1 -Show All -Strict #  -TagFilter ToTest # -TagFilter blobversion,qq
-Invoke-Pester C:\Users\weiwei\Desktop\PSH_Script\PSHTest\adls.ps1 -Show All -Strict
-Invoke-Pester C:\Users\weiwei\Desktop\PSH_Script\PSHTest\adls_setaclresusive.ps1 -Show All -Strict
-Invoke-Pester C:\Users\weiwei\Desktop\PSH_Script\PSHTest\srp.ps1  -Show All -Strict -ExcludeTagFilter "longrunning"  # -TagFilter "fail"
+Invoke-Pester $PSScriptRoott\dataplane.ps1 -Show All -Strict #  -TagFilter ToTest # -TagFilter blobversion,qq
+Invoke-Pester $PSScriptRoot\adls.ps1 -Show All -Strict
+Invoke-Pester $PSScriptRoot\adls_setaclresusive.ps1 -Show All -Strict
+Invoke-Pester $PSScriptRoot\srp.ps1  -Show All -Strict -ExcludeTagFilter "longrunning"  # -TagFilter "fail"
 
-Invoke-Pester C:\Users\weiwei\Desktop\PSH_Script\PSHTest\srp.ps1  -Show All -Strict -TagFilter "longrunning"
+Invoke-Pester $PSScriptRoot\srp.ps1  -Show All -Strict -TagFilter "longrunning"
 
 
 #Invoke-Pester C:\Users\weiwei\Desktop\PSH_Script\PSHTest\dataplane.ps1 -Show All -Strict -TagFilter accesspolicy


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

<!-- Please add a brief description of the changes made in this PR -->

Add some fix in my regression test for Az.Storage 5.3.0
1. Set ACL recusive : Server has change, so we can't update datalake gen2 items when it's leased. Update script to make test pass
2. Use "$PSScriptRoot" to replace hardcoded script location.
3. Add test case for allowedCopyScope and ListBlobProperties
4. Change some case from canary to westus, since when I run test, looks eastuseuap has problem to create account.
5. Some other fix to make variable aligned and avoid case fail.

TODO: 
1. The user identity test still can't pass (I test with old script)
2. Need add Encryption scope list case (I manually tested )

## Checklist

- [ ] I have read the [_Submitting Changes_](../blob/master/CONTRIBUTING.md#submitting-changes) section of [`CONTRIBUTING.md`](../blob/master/CONTRIBUTING.md)
- [ ] The title of the PR is clear and informative
- [ ] The appropriate `ChangeLog.md` file(s) has been updated:
    - For any service, the `ChangeLog.md` file can be found at `src/{{SERVICE}}/{{SERVICE}}/ChangeLog.md`
    - A snippet outlining the change(s) made in the PR should be written under the `## Upcoming Release` header -- no new version header should be added
- [ ] The PR does not introduce [breaking changes](../blob/master/documentation/breaking-changes/breaking-changes-definition.md)
- [ ] If applicable, the changes made in the PR have proper test coverage
- [ ] For public API changes to cmdlets:
    - [ ] a cmdlet design review was approved for the changes in [this repository](https://github.com/Azure/azure-powershell-cmdlet-review-pr) (_Microsoft internal only_)
    - [ ] the markdown help files have been regenerated using the commands listed [here](../blob/master/documentation/development-docs/help-generation.md#updating-all-markdown-files-in-a-module)
